### PR TITLE
Fix Node write failure case

### DIFF
--- a/src/main/java/com/xjeffrose/xio/client/loadbalancer/Node.java
+++ b/src/main/java/com/xjeffrose/xio/client/loadbalancer/Node.java
@@ -119,7 +119,7 @@ public class Node implements Closeable {
                 promise.setSuccess(null);
               } else {
                 log.error("Write error: ", channelFuture.cause());
-                promise.setFailure(future.cause());
+                promise.setFailure(channelFuture.cause());
               }
             }
           });


### PR DESCRIPTION
Need to use channelFuture.cause() if the writeAndFlush fails
for Node.send since future.cause() will alwasy be empty
when writeAndFlush is being called.