### PR TITLE
Fix XioService blocking

### DIFF
--- a/src/main/java/com/xjeffrose/xio/server/XioService.java
+++ b/src/main/java/com/xjeffrose/xio/server/XioService.java
@@ -109,7 +109,6 @@ public class XioService extends ChannelDuplexHandler {
     serviceList.stream().forEach(xs -> {
       ctx.pipeline().addLast(xs);
     });
-    ctx.pipeline().remove(this);
     if (!blockActive) {
       ctx.fireChannelActive();
     }

--- a/src/test/java/com/xjeffrose/xio/server/XioServiceTest.java
+++ b/src/test/java/com/xjeffrose/xio/server/XioServiceTest.java
@@ -1,5 +1,6 @@
 package com.xjeffrose.xio.server;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Map;
 import org.junit.Test;
 
@@ -13,5 +14,23 @@ public class XioServiceTest {
     XioService xioService = new XioService();
 
     assertEquals(xioService, xioService.andThen(xioService));
+  }
+
+  @Test
+  public void testChannelReadBlocking() {
+    XioService xioService = new XioService();
+    EmbeddedChannel channel = new EmbeddedChannel(xioService);
+    String message = "Test Message";
+
+    channel.writeInbound(message);
+
+    assertEquals(message, channel.inboundMessages().poll());
+
+    xioService.blockRead = true;
+
+    channel.writeInbound(message);
+
+    assertEquals(0, channel.inboundMessages().size());
+
   }
 }


### PR DESCRIPTION
Not sure if there are still plans to use XioService for blocking, but it wouldn't work if there were.  Does it need to add services to the pipeline?  Seems that XioPipelineAssembler does a pretty good job at letting us customize which handlers are added.
