### PR TITLE
PEM file parsing to work with Windows line separators

### DIFF
--- a/src/main/java/com/xjeffrose/xio/SSL/X509CertificateGenerator.java
+++ b/src/main/java/com/xjeffrose/xio/SSL/X509CertificateGenerator.java
@@ -58,15 +58,15 @@ public final class X509CertificateGenerator {
     return parseDERKeySpec(rawKeyString);
   }
 
-    public static DERKeySpec parseDERKeySpec(String rawKeyString) {
-      try {
-        // Base64 decode the data
-        Base64.Decoder b64decoder = Base64.getDecoder();
-        byte[] encoded = b64decoder.decode(
-          rawKeyString.replace("-----BEGIN RSA PRIVATE KEY-----", "")
-            .replace("-----END RSA PRIVATE KEY-----", "")
-            .replace(System.getProperty("line.separator"), "")
-        );
+  public static DERKeySpec parseDERKeySpec(String rawKeyString) {
+    try {
+      // Base64 decode the data
+      Base64.Decoder b64decoder = Base64.getDecoder();
+      byte[] encoded = b64decoder.decode(
+        rawKeyString.replace("-----BEGIN RSA PRIVATE KEY-----", "")
+          .replace("-----END RSA PRIVATE KEY-----", "")
+          .replace(System.getProperty("line.separator"), "")
+      );
 
       DerInputStream derReader = new DerInputStream(encoded);
       DerValue[] seq = derReader.getSequence(0);

--- a/src/main/java/com/xjeffrose/xio/SSL/X509CertificateGenerator.java
+++ b/src/main/java/com/xjeffrose/xio/SSL/X509CertificateGenerator.java
@@ -59,14 +59,14 @@ public final class X509CertificateGenerator {
   }
 
     public static DERKeySpec parseDERKeySpec(String rawKeyString) {
-    try {
-      // Base64 decode the data
-      Base64.Decoder b64decoder = Base64.getDecoder();
-      byte[] encoded = b64decoder.decode(
-          rawKeyString.replace("-----BEGIN RSA PRIVATE KEY-----\n", "")
-              .replace("-----END RSA PRIVATE KEY-----\n", "")
-              .replace("\n", "")
-      );
+      try {
+        // Base64 decode the data
+        Base64.Decoder b64decoder = Base64.getDecoder();
+        byte[] encoded = b64decoder.decode(
+          rawKeyString.replace("-----BEGIN RSA PRIVATE KEY-----", "")
+            .replace("-----END RSA PRIVATE KEY-----", "")
+            .replace(System.getProperty("line.separator"), "")
+        );
 
       DerInputStream derReader = new DerInputStream(encoded);
       DerValue[] seq = derReader.getSequence(0);


### PR DESCRIPTION
use line.separator instead of hard coded "\n" plus minor reformating 

Travis build passes https://travis-ci.org/TexanHogman/xio
