### PR TITLE
HTTP/1.1 message "sessions"

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http1MessageSession.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http1MessageSession.java
@@ -1,0 +1,190 @@
+package com.xjeffrose.xio.http;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+
+// Fun reading!
+// Pipelining: https://tools.ietf.org/html/rfc7230#section-6.3.2
+// https://en.wikipedia.org/wiki/HTTP_pipelining
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x
+
+// Scenarios
+// 1: client sends all of request before we respond
+// 2: client sends request1 and request2 before we respond (http pipelining)
+// 3: client sends part of request, we respond in full, client sends the rest of the request
+// 4: client sends part of the request, we respond in full, client sends nothing (need timeout to
+// detect)
+
+/**
+ * Http1MessageSession is a finite state machine to track the current HTTP/1.1 message session. This
+ * class exists to store the connection specific state of the message session, it should be attached
+ * to the Channel via the attr method.
+ */
+@Slf4j
+public class Http1MessageSession {
+  /*
+  This is an attempt at describing the state machine needed for doing
+  http pipelining. We haven't implemented this but it serves as a
+  document for why we're not supporting http pipelining.
+
+  @startuml
+  [*] -> NoMessages
+  NoMessages -> InitialRequestReceived
+  InitialRequestReceived -> InitialResponseSent
+  InitialResponseSent -> NoMessages
+
+  InitialRequestReceived -> PipelineRequestReceived
+  PipelineRequestReceived -> PipelineRequestReceived
+  PipelineRequestReceived -> PipelineLimitReached
+  PipelineLimitReached -> NoMessages
+
+  InitialResponseSent -> PipelineResponseSent
+  PipelineResponseSent -> PipelineResponseSent
+  PipelineResponseSent -> NoMessages
+  @enduml
+    */
+
+  public static class RequestMeta {
+    public final Request request;
+    public boolean requestFinished;
+    public boolean responseFinished;
+
+    RequestMeta(Request request, boolean requestFinished) {
+      this.request = request;
+      this.requestFinished = requestFinished;
+      responseFinished = false;
+    }
+  }
+
+  // We can only handle one request at a time, any additional requests will be ignored.
+  private RequestMeta initialRequest;
+  // The client tried to send another request before the first request was responded to.
+  private boolean clientTriedPipeline;
+
+  @VisibleForTesting
+  public RequestMeta initialRequest() {
+    return initialRequest;
+  }
+
+  private void reset() {
+    initialRequest = null;
+    clientTriedPipeline = false;
+  }
+
+  public Http1MessageSession() {
+    reset();
+  }
+
+  /**
+   * Called when the client has sent a Request.
+   *
+   * @param request The Request object that the client has sent
+   */
+  public void onRequest(Request request) {
+    if (initialRequest == null) {
+      boolean fullRequest = (request instanceof FullRequest);
+      initialRequest = new RequestMeta(request, fullRequest);
+    } else {
+      // log that the client is attempting to pipeline
+      if (clientTriedPipeline == false) {
+        // only log an error once
+        log.error(
+            "Client attempted to send Request before response finished (HTTP Pipelining): {}",
+            request);
+        clientTriedPipeline = true;
+      } else {
+        log.debug("Client attempted to send another pipelined request: {}", request);
+      }
+    }
+  }
+
+  /**
+   * Called when the client has sent a StreamingData object as part of a Request.
+   *
+   * @param data The StreamingData object that the client has sent
+   */
+  public void onRequestData(StreamingData data) {
+    if (initialRequest == null) {
+      log.error("Received StreamingData without a current Request, dropping data: {}", data);
+      return;
+    }
+
+    if (data.endOfStream()) {
+      initialRequest.requestFinished = true;
+    }
+  }
+
+  /**
+   * Called before sending a Response object to the client.
+   *
+   * @param response The Response object the server is about to send
+   */
+  public void onResponse(Response response) {
+    if (initialRequest != null) {
+      if (initialRequest.requestFinished == false) {
+        // We are responding before the request has finished.
+        // It's possible that we're being bad http1 actors by
+        // responding before the request is finished sending, we should log
+        // if/when that happens
+        log.error(
+            "Response is being sent before the request has finished processing: {}", response);
+      }
+
+      if (response instanceof FullResponse) {
+        initialRequest.responseFinished = true;
+      }
+    }
+  }
+
+  /**
+   * Called before a StreamingData object is sent to the client as part of a Response.
+   *
+   * @param data The StreamingData object the server is about to send
+   */
+  public void onResponseData(StreamingData data) {
+    if (initialRequest != null) {
+      if (data.endOfStream()) {
+        initialRequest.responseFinished = true;
+      }
+    } else {
+      log.error(
+          "Attempted to write StreamingData without a current Request, dropping data: {}", data);
+    }
+  }
+
+  /**
+   * Returns the Request object for the current session (if any).
+   *
+   * @return the current Request or null
+   */
+  public Request currentRequest() {
+    if (initialRequest != null) {
+      return initialRequest.request;
+    }
+    return null;
+  }
+
+  /**
+   * Should the server close the connection after sending the response? Usually true if the client
+   * has tried some unsupported action, like HTTP Pipelining.
+   *
+   * @return if the connection should be closed
+   */
+  public boolean closeConnection() {
+    return clientTriedPipeline;
+  }
+
+  /**
+   * Check if the message session has completed, if so remove state and prepare for the next
+   * session.
+   */
+  public void flush() {
+    // If we have a current request and we've seen all of the request data and all of the response
+    // data we can reset.
+    if (initialRequest != null
+        && initialRequest.requestFinished
+        && initialRequest.responseFinished) {
+      reset();
+    }
+  }
+}

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/Http1MessageSessionUnitTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/Http1MessageSessionUnitTest.java
@@ -1,0 +1,198 @@
+package com.xjeffrose.xio.http;
+
+import static io.netty.handler.codec.http.HttpMethod.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
+
+import io.netty.buffer.Unpooled;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class Http1MessageSessionUnitTest extends Assert {
+
+  Http1MessageSession session;
+
+  @Before
+  public void setUp() {
+    session = new Http1MessageSession();
+  }
+
+  @Test
+  public void testOnRequestFull() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+  }
+
+  @Test
+  public void testOnRequestStreaming() {
+    Request request =
+        DefaultStreamingRequest.builder()
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertFalse(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+  }
+
+  @Test
+  public void testOnRequestPipeline() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+    assertFalse(session.closeConnection());
+
+    session.onRequest(request);
+    assertTrue(session.closeConnection());
+  }
+
+  @Test
+  public void testOnRequestData() {
+    Request request =
+        DefaultStreamingRequest.builder()
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertFalse(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+    assertFalse(session.closeConnection());
+
+    StreamingData data =
+        DefaultStreamingData.builder()
+            .content(Unpooled.EMPTY_BUFFER)
+            .endOfStream(true)
+            .trailingHeaders(new DefaultHeaders())
+            .build();
+    session.onRequestData(data);
+    assertTrue(session.initialRequest().requestFinished);
+  }
+
+  @Test
+  public void testOnResponseFull() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+
+    Response response =
+        DefaultFullResponse.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .status(OK)
+            .headers(new DefaultHeaders())
+            .build();
+    session.onResponse(response);
+    assertTrue(session.initialRequest().requestFinished);
+    assertTrue(session.initialRequest().responseFinished);
+  }
+
+  @Test
+  public void testOnResponseStreaming() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+
+    Response response =
+        DefaultStreamingResponse.builder().status(OK).headers(new DefaultHeaders()).build();
+    session.onResponse(response);
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+  }
+
+  @Test
+  public void testOnResponseData() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+
+    Response response =
+        DefaultStreamingResponse.builder().status(OK).headers(new DefaultHeaders()).build();
+    session.onResponse(response);
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+
+    StreamingData data =
+        DefaultStreamingData.builder()
+            .content(Unpooled.EMPTY_BUFFER)
+            .endOfStream(true)
+            .trailingHeaders(new DefaultHeaders())
+            .build();
+    session.onResponseData(data);
+    assertTrue(session.initialRequest().requestFinished);
+    assertTrue(session.initialRequest().responseFinished);
+  }
+
+  @Test
+  public void testFlush() {
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    session.onRequest(request);
+
+    assertTrue(session.initialRequest().requestFinished);
+    assertFalse(session.initialRequest().responseFinished);
+    session.flush();
+    assertNotNull(session.currentRequest());
+
+    Response response =
+        DefaultFullResponse.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .status(OK)
+            .headers(new DefaultHeaders())
+            .build();
+    session.onResponse(response);
+    assertTrue(session.initialRequest().requestFinished);
+    assertTrue(session.initialRequest().responseFinished);
+    session.flush();
+    assertNull(session.currentRequest());
+  }
+}

--- a/xio-test/pom.xml
+++ b/xio-test/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.xjeffrose</groupId>
   <artifactId>xio-test</artifactId>
-  <version>0.13.0</version>
+  <version>0.13.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>xio-test</name>
   <description>Testing package for xio</description>


### PR DESCRIPTION
In order to know when to cleanup some HTTP objects we create we need a concept of a session (this is unrelated to anything having to do with cookies or session affinity). We introduce the concept of a Http1MessageSession that is associated with a single channel. If a client is behaving improperly (HTTP Pipelining) we respond to their first request and hang up. We also log when we get ourselves into a bad state.