### PR TITLE
wk/TACO-11 adding zipkin tracing to Client and refactoring call sites…

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/application/ApplicationConfig.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/application/ApplicationConfig.java
@@ -7,6 +7,7 @@ import com.xjeffrose.xio.bootstrap.ChannelConfiguration;
 import com.xjeffrose.xio.bootstrap.ServerChannelConfiguration;
 import com.xjeffrose.xio.core.NullZkClient;
 import com.xjeffrose.xio.core.ZkClient;
+import com.xjeffrose.xio.tracing.XioTracing;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,8 +23,7 @@ public class ApplicationConfig {
   @Getter private final String zookeeperCluster;
   @Getter private final String ipFilterPath;
   @Getter private final String http1FilterPath;
-  @Getter private final String zipkinUrl;
-  @Getter private final float samplingRate;
+  @Getter private final XioTracing tracing;
 
   public ApplicationConfig(Config config) {
     this.config = config;
@@ -35,8 +35,7 @@ public class ApplicationConfig {
     zookeeperCluster = config.getString("settings.zookeeper.cluster");
     ipFilterPath = config.getString("settings.configurationManager.ipFilter.path");
     http1FilterPath = config.getString("settings.configurationManager.http1Filter.path");
-    zipkinUrl = config.getString("settings.tracing.zipkinUrl");
-    samplingRate = ((Double) config.getDouble("settings.tracing.samplingRate")).floatValue();
+    tracing = new XioTracing(config);
   }
 
   public static ApplicationConfig fromConfig(String key, Config config) {

--- a/xio-core/src/main/java/com/xjeffrose/xio/application/ApplicationState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/application/ApplicationState.java
@@ -11,12 +11,11 @@ import com.xjeffrose.xio.http.ClientState;
 import com.xjeffrose.xio.http.DefaultRouter;
 import com.xjeffrose.xio.http.Router;
 import com.xjeffrose.xio.tracing.XioTracing;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import lombok.val;
 
 public class ApplicationState {
 
@@ -42,9 +41,11 @@ public class ApplicationState {
 
   public ApplicationState(ApplicationConfig config) {
     this.config = config;
+    val settings = config.settings();
+    this.tracing = config.getTracing();
+
     zkClient = config.zookeeperClient();
     channelConfiguration = config.serverChannelConfig();
-    tracing = new XioTracing(config);
 
     ipFilterConfig = new AtomicReference<>(new IpFilterConfig());
     zkClient.registerUpdater(
@@ -90,11 +91,7 @@ public class ApplicationState {
 
   public ClientState createClientState(
       ClientChannelConfiguration channelConfig, ClientConfig config) {
-
-    Supplier<ChannelHandler> tracingHandler =
-        () -> tracing().newClientHandler(config.isTlsEnabled());
-
-    return new ClientState(channelConfig, config, tracingHandler);
+    return new ClientState(channelConfig, config);
   }
 
   public ClientState createClientState(ClientConfig config) {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
@@ -2,6 +2,7 @@ package com.xjeffrose.xio.http;
 
 import com.xjeffrose.xio.core.XioIdleDisconnectHandler;
 import com.xjeffrose.xio.core.XioMessageLogger;
+import com.xjeffrose.xio.tracing.XioTracing;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -12,19 +13,22 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.PromiseCombiner;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 @Slf4j
 public class Client {
 
   private final ClientState state;
   private final Supplier<ChannelHandler> appHandler;
+  private final XioTracing tracing;
   private final ChannelFutureListener connectionListener;
   private final ChannelFutureListener writeListener;
   private Channel channel;
 
-  public Client(ClientState state, Supplier<ChannelHandler> appHandler) {
+  public Client(ClientState state, Supplier<ChannelHandler> appHandler, XioTracing tracing) {
     this.state = state;
     this.appHandler = appHandler;
+    this.tracing = tracing;
     connectionListener =
         f -> {
           if (f.isDone() && f.isSuccess()) {
@@ -68,7 +72,15 @@ public class Client {
                 .addLast(
                     "negotiation handler",
                     new HttpClientNegotiationHandler(Client.this::buildHttp2Handler))
-                .addLast("codec", CodecPlaceholderHandler.INSTANCE)
+                .addLast("codec", CodecPlaceholderHandler.INSTANCE);
+            if (tracing != null) {
+              val traceHandler = tracing.newClientHandler(state.config.isTlsEnabled());
+              if (traceHandler != null) {
+                channel.pipeline().addLast("distributed tracing", traceHandler);
+              }
+            }
+            channel
+                .pipeline()
                 .addLast("application codec", ApplicationCodecPlaceholderHandler.INSTANCE)
                 .addLast("idle handler", new XioIdleDisconnectHandler(60, 60, 60))
                 .addLast("message logging", new XioMessageLogger(Client.class, "objects"))

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientFactory.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientFactory.java
@@ -3,6 +3,7 @@ package com.xjeffrose.xio.http;
 import com.xjeffrose.xio.bootstrap.ChannelConfiguration;
 import com.xjeffrose.xio.bootstrap.ClientChannelConfiguration;
 import com.xjeffrose.xio.client.ClientConfig;
+import com.xjeffrose.xio.tracing.XioTracing;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AttributeKey;
 
@@ -17,12 +18,13 @@ public abstract class ClientFactory {
     return ChannelConfiguration.clientConfig(ctx.channel().eventLoop());
   }
 
-  public abstract Client createClient(ChannelHandlerContext ctx, ClientConfig config);
+  public abstract Client createClient(
+      ChannelHandlerContext ctx, ClientConfig config, XioTracing tracing);
 
-  public Client getClient(ChannelHandlerContext ctx, ClientConfig config) {
+  public Client getClient(ChannelHandlerContext ctx, ClientConfig config, XioTracing tracing) {
     Client client = ctx.channel().attr(CLIENT_KEY).get();
     if (client == null) {
-      client = createClient(ctx, config);
+      client = createClient(ctx, config, tracing);
       ctx.channel().attr(CLIENT_KEY).set(client);
     }
     return client;

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientState.java
@@ -3,10 +3,8 @@ package com.xjeffrose.xio.http;
 import com.xjeffrose.xio.SSL.SslContextFactory;
 import com.xjeffrose.xio.bootstrap.ClientChannelConfiguration;
 import com.xjeffrose.xio.client.ClientConfig;
-import io.netty.channel.ChannelHandler;
 import io.netty.handler.ssl.SslContext;
 import java.net.InetSocketAddress;
-import java.util.function.Supplier;
 
 // TODO(CK): This needs to replace the ClientState in client
 public class ClientState {
@@ -15,7 +13,6 @@ public class ClientState {
   public final ClientConfig config;
   public final InetSocketAddress remote;
   public final SslContext sslContext;
-  public final Supplier<ChannelHandler> tracingHandler;
 
   private static SslContext sslContext(boolean enableTls, ClientConfig clientConfig) {
     if (enableTls) {
@@ -29,32 +26,25 @@ public class ClientState {
       ClientChannelConfiguration channelConfig,
       ClientConfig config,
       InetSocketAddress remote,
-      SslContext sslContext,
-      Supplier<ChannelHandler> tracingHandler) {
+      SslContext sslContext) {
     this.channelConfig = channelConfig;
     this.config = config;
     this.remote = remote;
     this.sslContext = sslContext;
-    this.tracingHandler = tracingHandler;
   }
 
   public ClientState(
       ClientChannelConfiguration channelConfig,
       ClientConfig config,
       InetSocketAddress remote,
-      boolean enableTls,
-      Supplier<ChannelHandler> tracingHandler) {
-    this(channelConfig, config, remote, sslContext(enableTls, config), tracingHandler);
+      boolean enableTls) {
+    this(channelConfig, config, remote, sslContext(enableTls, config));
   }
 
-  public ClientState(
-      ClientChannelConfiguration channelConfig,
-      ClientConfig config,
-      Supplier<ChannelHandler> tracingHandler) {
+  public ClientState(ClientChannelConfiguration channelConfig, ClientConfig config) {
     this.channelConfig = channelConfig;
     this.config = config;
     this.remote = config.remote();
     this.sslContext = sslContext(config.isTlsEnabled(), config);
-    this.tracingHandler = tracingHandler;
   }
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyClientFactory.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyClientFactory.java
@@ -2,6 +2,7 @@ package com.xjeffrose.xio.http;
 
 import com.xjeffrose.xio.application.ApplicationState;
 import com.xjeffrose.xio.client.ClientConfig;
+import com.xjeffrose.xio.tracing.XioTracing;
 import io.netty.channel.ChannelHandlerContext;
 
 /** Generates an http proxy Client objects */
@@ -25,9 +26,9 @@ public class ProxyClientFactory extends ClientFactory {
   }
 
   @Override
-  public Client createClient(ChannelHandlerContext ctx, ClientConfig config) {
+  public Client createClient(ChannelHandlerContext ctx, ClientConfig config, XioTracing tracing) {
     ClientState clientState = state.createClientState(channelConfig(ctx), config);
     // TODO(CK): this handler should be notifying a connection pool on release
-    return new Client(clientState, () -> new ProxyBackendHandler(ctx));
+    return new Client(clientState, () -> new ProxyBackendHandler(ctx), tracing);
   }
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyHandler.java
@@ -2,6 +2,7 @@ package com.xjeffrose.xio.http;
 
 import com.xjeffrose.xio.client.ClientConfig;
 import com.xjeffrose.xio.core.SocketAddressHelper;
+import com.xjeffrose.xio.tracing.XioTracing;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AsciiString;
 import java.util.Optional;
@@ -15,12 +16,17 @@ public class ProxyHandler implements PipelineRequestHandler {
   protected final ClientFactory factory;
   protected final ProxyRouteConfig config;
   protected final SocketAddressHelper addressHelper;
+  protected final XioTracing tracing;
 
   public ProxyHandler(
-      ClientFactory factory, ProxyRouteConfig config, SocketAddressHelper addressHelper) {
+      ClientFactory factory,
+      ProxyRouteConfig config,
+      SocketAddressHelper addressHelper,
+      XioTracing tracing) {
     this.factory = factory;
     this.config = config;
     this.addressHelper = addressHelper;
+    this.tracing = tracing;
   }
 
   public ClientConfig getClientConfig(Request request) {
@@ -116,7 +122,7 @@ public class ProxyHandler implements PipelineRequestHandler {
     // 3) set the tracing span (if there is one)
 
     ClientConfig clientConfig = getClientConfig(request);
-    Client client = factory.getClient(ctx, clientConfig);
+    Client client = factory.getClient(ctx, clientConfig, tracing);
 
     if (!request.startOfStream()) {
       log.debug("not start of stream");

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/RoundRobinProxyHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/RoundRobinProxyHandler.java
@@ -2,6 +2,7 @@ package com.xjeffrose.xio.http;
 
 import com.xjeffrose.xio.client.ClientConfig;
 import com.xjeffrose.xio.core.SocketAddressHelper;
+import com.xjeffrose.xio.tracing.XioTracing;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.val;
 
@@ -9,8 +10,11 @@ public class RoundRobinProxyHandler extends ProxyHandler {
   private final AtomicInteger next = new AtomicInteger();
 
   public RoundRobinProxyHandler(
-      ClientFactory factory, ProxyRouteConfig config, SocketAddressHelper addressHelper) {
-    super(factory, config, addressHelper);
+      ClientFactory factory,
+      ProxyRouteConfig config,
+      SocketAddressHelper addressHelper,
+      XioTracing tracing) {
+    super(factory, config, addressHelper, tracing);
   }
 
   @Override

--- a/xio-core/src/main/java/com/xjeffrose/xio/pipeline/XioBasePipeline.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/pipeline/XioBasePipeline.java
@@ -18,6 +18,7 @@ import com.xjeffrose.xio.server.XioServerState;
 import com.xjeffrose.xio.server.XioWebApplicationFirewall;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
+import lombok.val;
 
 public abstract class XioBasePipeline implements XioPipelineFragment {
 
@@ -86,7 +87,10 @@ public abstract class XioBasePipeline implements XioPipelineFragment {
     } else {
       throw new RuntimeException("No codec configured");
     }
-    addHandler(pipeline, "distributed tracing", state.tracingHandler(appState));
+    val traceHandler = state.tracingHandler(appState);
+    if (traceHandler != null) {
+      addHandler(pipeline, "distributed tracing", traceHandler);
+    }
     addHandler(pipeline, "application codec", getApplicationCodec());
     addHandler(pipeline, "application router", getApplicationRouter());
     addHandler(pipeline, "authentication handler", getAuthenticationHandler());

--- a/xio-core/src/main/java/com/xjeffrose/xio/tracing/XioTracing.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/tracing/XioTracing.java
@@ -4,7 +4,9 @@ import brave.Tracing;
 import brave.context.slf4j.MDCCurrentTraceContext;
 import brave.http.HttpTracing;
 import brave.sampler.Sampler;
-import com.xjeffrose.xio.application.ApplicationConfig;
+import com.typesafe.config.Config;
+import lombok.NonNull;
+import lombok.val;
 import zipkin.Span;
 import zipkin.reporter.AsyncReporter;
 import zipkin.reporter.Reporter;
@@ -14,25 +16,29 @@ public class XioTracing {
 
   private final Tracing tracing;
 
-  private Reporter<Span> buildReporter(ApplicationConfig config) {
-    return AsyncReporter.builder(OkHttpSender.create(config.getZipkinUrl())).build();
+  private Reporter<Span> buildReporter(@NonNull String zipkinUrl) {
+    return AsyncReporter.builder(OkHttpSender.create(zipkinUrl)).build();
   }
 
-  private Tracing buildTracing(ApplicationConfig config) {
-    if (config.getZipkinUrl().isEmpty() || !(config.getSamplingRate() > 0f)) {
+  private Tracing buildTracing(
+      @NonNull String name, @NonNull String zipkinUrl, float samplingRate) {
+    if (zipkinUrl.isEmpty() || !(samplingRate > 0f)) {
       return null;
     }
     return Tracing.newBuilder()
-        .localServiceName(config.getName())
+        .localServiceName(name)
         // puts trace IDs into logs
         .currentTraceContext(MDCCurrentTraceContext.create())
-        .reporter(buildReporter(config))
-        .sampler(Sampler.create(config.getSamplingRate()))
+        .reporter(buildReporter(zipkinUrl))
+        .sampler(Sampler.create(samplingRate))
         .build();
   }
 
-  public XioTracing(ApplicationConfig config) {
-    tracing = buildTracing(config);
+  public XioTracing(Config config) {
+    val name = config.getString("name");
+    val zipkinUrl = config.getString("settings.tracing.zipkinUrl");
+    float samplingRate = ((Double) config.getDouble("settings.tracing.samplingRate")).floatValue();
+    tracing = buildTracing(name, zipkinUrl, samplingRate);
   }
 
   public boolean enabled() {

--- a/xio-core/src/test/java/com/xjeffrose/xio/application/ApplicationConfigTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/application/ApplicationConfigTest.java
@@ -19,7 +19,7 @@ public class ApplicationConfigTest extends Assert {
     assertEquals("localhost:2181", config.getZookeeperCluster());
     assertEquals("/xio/ipFilterRules", config.getIpFilterPath());
     assertEquals("/xio/http1FilterRules", config.getHttp1FilterPath());
-    assertEquals("http://127.0.0.1:9411/api/v1/spans", config.getZipkinUrl());
-    assertEquals(0.50, config.getSamplingRate(), 0.001);
+    // assertEquals("http://127.0.0.1:9411/api/v1/spans", config.getZipkinUrl());
+    // assertEquals(0.50, config.getSamplingRate(), 0.001);
   }
 }

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ClientTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ClientTest.java
@@ -1,0 +1,112 @@
+package com.xjeffrose.xio.http;
+
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import com.typesafe.config.ConfigFactory;
+import com.xjeffrose.xio.bootstrap.ChannelConfiguration;
+import com.xjeffrose.xio.client.ClientConfig;
+import com.xjeffrose.xio.tracing.HttpClientTracingHandler;
+import com.xjeffrose.xio.tracing.XioTracing;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.*;
+import lombok.val;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.*;
+
+public class ClientTest extends Assert {
+
+  private Client subject;
+  @Mock private XioTracing tracing;
+  @Mock private HttpClientTracingHandler tracingHandler;
+
+  ChannelHandler appHandler =
+      new ChannelHandler() {
+        @Override
+        public void handlerAdded(ChannelHandlerContext channelHandlerContext) throws Exception {}
+
+        @Override
+        public void handlerRemoved(ChannelHandlerContext channelHandlerContext) throws Exception {}
+
+        @Override
+        public void exceptionCaught(
+            ChannelHandlerContext channelHandlerContext, Throwable throwable) throws Exception {}
+      };
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @After
+  public void tearDown() {
+    Mockito.reset(tracing);
+    Mockito.reset(tracingHandler);
+  }
+
+  @Test
+  public void testDisabledTracing() {
+    val channelConfig = ChannelConfiguration.clientConfig(1, "worker");
+    val clientConfig =
+        new ClientConfig(ConfigFactory.load().getConfig("xio.invalidZipkinParameters"));
+    val clientState = new ClientState(channelConfig, clientConfig);
+
+    subject =
+        new Client(
+            clientState,
+            () -> {
+              return appHandler;
+            },
+            null);
+
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    val writeFuture = subject.write(request);
+
+    // Assert that we did not call handlerAdded when the tracing/traceHandler is null
+    // This would crash if we tried adding a null handler, thus no explicit assertion
+  }
+
+  @Test
+  public void testEnabledTracing() {
+    val channelConfig = ChannelConfiguration.clientConfig(1, "worker");
+    val clientConfig =
+        new ClientConfig(ConfigFactory.load().getConfig("xio.validZipkinParameters"));
+    val clientState = new ClientState(channelConfig, clientConfig);
+    when(tracing.newClientHandler(clientConfig.getTls().isUseSsl())).thenReturn(tracingHandler);
+
+    subject =
+        new Client(
+            clientState,
+            () -> {
+              return appHandler;
+            },
+            tracing);
+    Request request =
+        DefaultFullRequest.builder()
+            .body(Unpooled.EMPTY_BUFFER)
+            .headers(new DefaultHeaders())
+            .method(GET)
+            .path("/")
+            .build();
+    val writeFuture = subject.write(request);
+
+    // Assert that we did DO call handlerAdded when the tracing/traceHandler is non-null
+    try {
+      ArgumentCaptor<ChannelHandlerContext> captor =
+          ArgumentCaptor.forClass(ChannelHandlerContext.class);
+      Mockito.verify(tracingHandler, times(1)).handlerAdded(captor.capture());
+    } catch (Exception e) {
+      fail();
+    }
+  }
+}

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/EdgeProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/EdgeProxyFunctionalTest.java
@@ -140,7 +140,10 @@ public class EdgeProxyFunctionalTest extends Assert {
                                   this,
                                   prConfig,
                                   new ProxyHandler(
-                                      clientFactory, prConfig, new SocketAddressHelper())))
+                                      clientFactory,
+                                      prConfig,
+                                      new SocketAddressHelper(),
+                                      this.tracing())))
                       // collect the stream of ProxyRouteState into
                       // LinkedHashMap<String, ProxyRouteState> where the
                       // route path is the key and

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcFunctionalTest.java
@@ -15,6 +15,7 @@ import com.xjeffrose.xio.pipeline.SmartHttpPipeline;
 import com.xjeffrose.xio.server.XioServer;
 import com.xjeffrose.xio.server.XioServerConfig;
 import com.xjeffrose.xio.server.XioServerState;
+import com.xjeffrose.xio.tracing.XioTracing;
 import helloworld.*;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
@@ -371,13 +372,15 @@ public class GrpcFunctionalTest extends Assert {
 
     ClientConfig config = ClientConfig.fromConfig("xio.h2TestClient");
     // ProxyConfig proxyConfig = ProxyConfig.parse("https://127.0.0.1:" + server.getPort() + "/");
-    ProxyRouteConfig proxyConfig = new ProxyRouteConfig(root.getConfig("xio.testProxyRoute"));
+    ProxyRouteConfig proxyConfig =
+        new ProxyRouteConfig(ConfigFactory.load().getConfig("xio.testProxyRoute"));
     ClientFactory factory =
         new ClientFactory() {
           @Override
-          public Client createClient(ChannelHandlerContext ctx, ClientConfig config) {
-            ClientState clientState = new ClientState(channelConfig(ctx), config, () -> null);
-            return new Client(clientState, () -> new ProxyBackendHandler(ctx));
+          public Client createClient(
+              ChannelHandlerContext ctx, ClientConfig config, XioTracing tracing) {
+            ClientState clientState = new ClientState(channelConfig(ctx), config);
+            return new Client(clientState, () -> new ProxyBackendHandler(ctx), tracing);
           }
         };
 
@@ -398,7 +401,10 @@ public class GrpcFunctionalTest extends Assert {
                                 appState,
                                 proxyConfig,
                                 new ProxyHandler(
-                                    factory, proxyConfig, new SocketAddressHelper()))));
+                                    factory,
+                                    proxyConfig,
+                                    new SocketAddressHelper(),
+                                    appState.tracing()))));
                   }
                 });
 

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
@@ -12,6 +12,7 @@ import com.xjeffrose.xio.core.SocketAddressHelper;
 import com.xjeffrose.xio.fixtures.JulBridge;
 import com.xjeffrose.xio.fixtures.OkHttpUnsafe;
 import com.xjeffrose.xio.pipeline.SmartHttpPipeline;
+import com.xjeffrose.xio.tracing.XioTracing;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
@@ -51,13 +52,15 @@ public class ReverseProxyFunctionalTest extends Assert {
   Application reverseProxy;
   MockWebServer server;
 
-  static Application setupReverseProxy(ApplicationConfig appConfig, ProxyRouteConfig proxyConfig) {
+  static Application setupReverseProxy(
+      ApplicationConfig appConfig, ProxyRouteConfig proxyConfig, XioTracing tracing) {
     ClientFactory factory =
         new ClientFactory() {
           @Override
-          public Client createClient(ChannelHandlerContext ctx, ClientConfig config) {
-            ClientState clientState = new ClientState(channelConfig(ctx), config, () -> null);
-            return new Client(clientState, () -> new ProxyBackendHandler(ctx));
+          public Client createClient(
+              ChannelHandlerContext ctx, ClientConfig config, XioTracing tracing) {
+            ClientState clientState = new ClientState(channelConfig(ctx), config);
+            return new Client(clientState, () -> new ProxyBackendHandler(ctx), tracing);
           }
         };
 
@@ -71,7 +74,8 @@ public class ReverseProxyFunctionalTest extends Assert {
                       public ChannelHandler getApplicationRouter() {
                         return new PipelineRouter(
                             ImmutableMap.of(),
-                            new ProxyHandler(factory, proxyConfig, new SocketAddressHelper()));
+                            new ProxyHandler(
+                                factory, proxyConfig, new SocketAddressHelper(), tracing));
                       }
                     }))
         .build();
@@ -115,7 +119,9 @@ public class ReverseProxyFunctionalTest extends Assert {
     Config root = ConfigFactory.load();
     ProxyRouteConfig proxyConfig = new ProxyRouteConfig(root.getConfig("xio.testProxyRoute"));
 
-    reverseProxy = setupReverseProxy(appConfig, proxyConfig);
+    reverseProxy =
+        setupReverseProxy(
+            appConfig, proxyConfig, new XioTracing(root.getConfig("xio.testProxyRoute")));
   }
 
   void setupClient(boolean h2) throws Exception {

--- a/xio-core/src/test/java/com/xjeffrose/xio/tracing/XioTracingTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/tracing/XioTracingTest.java
@@ -1,0 +1,40 @@
+package com.xjeffrose.xio.tracing;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XioTracingTest extends Assert {
+
+  private XioTracing subject;
+  private Config validParametersConfig;
+  private Config invalidParametersConfig;
+
+  @Before
+  public void setUp() {
+    validParametersConfig = ConfigFactory.load().getConfig("xio.validZipkinParameters");
+    invalidParametersConfig = ConfigFactory.load().getConfig("xio.invalidZipkinParameters");
+  }
+
+  @Test
+  public void testValidParametersConfig() {
+    // This when the zipkinurl is non-empty AND the sampling rate is > 0.0f
+    subject = new XioTracing(validParametersConfig);
+    assertTrue(subject.newClientHandler(true) != null);
+    assertTrue(subject.newClientHandler(false) != null);
+    assertTrue(subject.newServerHandler(true) != null);
+    assertTrue(subject.newServerHandler(false) != null);
+  }
+
+  @Test
+  public void testInvalidParametersConfig() {
+    // This when the zipkinurl is empty OR the sampling rate is <= 0.0f
+    subject = new XioTracing(invalidParametersConfig);
+    assertTrue(subject.newClientHandler(true) == null);
+    assertTrue(subject.newClientHandler(false) == null);
+    assertTrue(subject.newServerHandler(true) == null);
+    assertTrue(subject.newServerHandler(false) == null);
+  }
+}

--- a/xio-core/src/test/resources/application.conf
+++ b/xio-core/src/test/resources/application.conf
@@ -46,8 +46,13 @@ xio {
 
   h2TestClient = ${xio.clientTemplate} {
     name = "test client"
+    settings {
+      tracing {
+        zipkinUrl = "http://127.0.0.1:9411/api/v1/spans"
+        samplingRate = 0.50
+      }
+    }
   }
-
 
   testServer = ${xio.serverTemplate} {
     name = "test"
@@ -140,6 +145,10 @@ xio {
       tls {
         useSsl = false
         logInsecureConfig = false
+      }
+      tracing {
+        zipkinUrl = "http://127.0.0.1:9411/api/v1/spans"
+        samplingRate = 0.50
       }
     }
   }
@@ -248,6 +257,12 @@ xio {
         name = "test client"
       }
     ]
+    settings {
+      tracing {
+        zipkinUrl = "http://127.0.0.1:9411/api/v1/spans"
+        samplingRate = 0.50
+      }
+    }
     proxyHostPolicy = "UseRequestHeader"
     proxyHost = ""
     proxyPath = "/"
@@ -258,6 +273,10 @@ xio {
     settings {
       zookeeper {
         cluster = ""
+      }
+      tracing {
+        zipkinUrl = "http://127.0.0.1:9411/api/v1/spans"
+        samplingRate = 0.50
       }
     }
     servers {
@@ -322,4 +341,31 @@ xio {
     ]
   }
 
+  invalidZipkinParameters = ${xio.clientTemplate} {
+    name = invalidZipkinParameters
+    settings {
+      tracing {
+        zipkinUrl = ""
+        samplingRate = -0.50
+      }
+      tls {
+        useSsl = false
+        logInsecureConfig = false
+      }
+    }
+  }
+
+  validZipkinParameters  = ${xio.clientTemplate} {
+    name = missingZipkinParameters
+    settings {
+      tracing {
+        zipkinUrl = "http://127.0.0.1:9411/api/v1/spans"
+        samplingRate = 0.50
+      }
+      tls {
+        useSsl = false
+        logInsecureConfig = false
+      }
+    }
+  }
 }


### PR DESCRIPTION
MOVING THIS OVER TO dc/TACO-11, but will incorporate Will Kamps suggestions

wk/TACO-11 adding zipkin tracing to Client and refactoring call sites and adding backfilling some tests.
Now the Client takes an xioTracing as a direct constructor dependency and the ApplicationConfig creates the xioTracing dependency