### PR TITLE
TACO-35 - adding span to Request object

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/client/http/HttpClient.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/client/http/HttpClient.java
@@ -21,7 +21,7 @@ public class HttpClient {
 
   public void write(HttpRequest request, TraceContext context) {
     request.headers().set("Host", hostHeader);
-    client.write(new XioRequest(request, context));
+    client.write(new XioRequest<>(request, context));
   }
 
   public void write(HttpRequest request) {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultFullRequest.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultFullRequest.java
@@ -1,12 +1,13 @@
 package com.xjeffrose.xio.http;
 
+import brave.Span;
 import com.google.auto.value.AutoValue;
 import com.xjeffrose.xio.core.internal.UnstableApi;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import java.util.Optional;
-import lombok.Builder;
+import javax.annotation.Nullable;
 import lombok.ToString;
 
 /** Value class for representing an outgoing HTTP1/2 Request, for use in a client. */
@@ -30,6 +31,9 @@ public abstract class DefaultFullRequest implements FullRequest {
 
   public abstract int streamId();
 
+  @Nullable
+  public abstract Span traceSpan();
+
   /** Not intended to be called. */
   @Override
   public String version() {
@@ -52,6 +56,8 @@ public abstract class DefaultFullRequest implements FullRequest {
     public abstract Builder headers(Headers headers);
 
     public abstract Builder streamId(int streamId);
+
+    public abstract Builder traceSpan(Span span);
 
     public abstract DefaultFullRequest build();
 

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultStreamingRequest.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultStreamingRequest.java
@@ -1,18 +1,19 @@
 package com.xjeffrose.xio.http;
 
+import brave.Span;
 import com.google.auto.value.AutoValue;
 import com.xjeffrose.xio.core.internal.UnstableApi;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import java.util.Optional;
-import lombok.Builder;
+import javax.annotation.Nullable;
 import lombok.ToString;
 
 /** Value class for representing a streaming outgoing HTTP1/2 Request, for use in a client. */
 @UnstableApi
 @AutoValue
 @ToString
-public abstract class DefaultStreamingRequest implements StreamingRequest {
+public abstract class DefaultStreamingRequest implements StreamingRequest, Traceable {
 
   @Override
   public boolean startOfStream() {
@@ -26,6 +27,9 @@ public abstract class DefaultStreamingRequest implements StreamingRequest {
   public abstract Headers headers();
 
   public abstract int streamId();
+
+  @Nullable
+  public abstract Span traceSpan();
 
   /** Not intended to be called. */
   @Override
@@ -47,6 +51,8 @@ public abstract class DefaultStreamingRequest implements StreamingRequest {
     public abstract Builder headers(Headers headers);
 
     public abstract Builder streamId(int streamId);
+
+    public abstract Builder traceSpan(Span span);
 
     public abstract DefaultStreamingRequest build();
 

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Request.java
@@ -7,7 +7,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 
 @UnstableApi
-public interface Request {
+public interface Request extends Traceable {
 
   boolean startOfStream();
 

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/StreamingRequestData.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/StreamingRequestData.java
@@ -4,7 +4,7 @@ import brave.Span;
 import com.xjeffrose.xio.core.internal.UnstableApi;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.ToString;
 
 @UnstableApi
@@ -76,7 +76,7 @@ public class StreamingRequestData implements Request, StreamingData {
 
   // region Traceable
 
-  @Nonnull
+  @Nullable
   @Override
   public Span traceSpan() {
     return span;

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/StreamingRequestData.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/StreamingRequestData.java
@@ -1,8 +1,10 @@
 package com.xjeffrose.xio.http;
 
+import brave.Span;
 import com.xjeffrose.xio.core.internal.UnstableApi;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
+import javax.annotation.Nonnull;
 import lombok.ToString;
 
 @UnstableApi
@@ -11,11 +13,19 @@ public class StreamingRequestData implements Request, StreamingData {
 
   private final Request request;
   private final StreamingData data;
+  private final Span span;
 
-  public StreamingRequestData(Request request, StreamingData data) {
+  public StreamingRequestData(Request request, StreamingData data, Span span) {
     this.request = request;
     this.data = data;
+    this.span = span;
   }
+
+  public StreamingRequestData(Request request, StreamingData data) {
+    this(request, data, null);
+  }
+
+  // region Request
 
   @Override
   public boolean startOfStream() {
@@ -62,6 +72,20 @@ public class StreamingRequestData implements Request, StreamingData {
     return request.body();
   }
 
+  // endregion
+
+  // region Traceable
+
+  @Nonnull
+  @Override
+  public Span traceSpan() {
+    return span;
+  }
+
+  // endregion
+
+  // region StreamingData
+
   @Override
   public ByteBuf content() {
     return data.content();
@@ -76,4 +100,7 @@ public class StreamingRequestData implements Request, StreamingData {
   public Headers trailingHeaders() {
     return data.trailingHeaders();
   }
+
+  // endregion
+
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Traceable.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Traceable.java
@@ -1,0 +1,10 @@
+package com.xjeffrose.xio.http;
+
+import brave.Span;
+import javax.annotation.Nullable;
+
+public interface Traceable {
+
+  @Nullable
+  Span traceSpan();
+}

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Request.java
@@ -1,20 +1,28 @@
 package com.xjeffrose.xio.http.internal;
 
+import brave.Span;
 import com.xjeffrose.xio.http.FullRequest;
 import com.xjeffrose.xio.http.Headers;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpUtil;
+import javax.annotation.Nullable;
 
 public class FullHttp1Request implements FullRequest {
 
   private final FullHttpRequest delegate;
   private final Http1Headers headers;
+  private final Span span;
+
+  public FullHttp1Request(FullHttpRequest delegate, @Nullable Span span) {
+    this.delegate = delegate;
+    this.headers = new Http1Headers(delegate.headers());
+    this.span = span;
+  }
 
   public FullHttp1Request(FullHttpRequest delegate) {
-    this.delegate = delegate;
-    headers = new Http1Headers(delegate.headers());
+    this(delegate, null);
   }
 
   @Override
@@ -61,4 +69,15 @@ public class FullHttp1Request implements FullRequest {
   public ByteBuf body() {
     return delegate.content();
   }
+
+  // endregion
+
+  // region Traceable
+
+  @Override
+  public Span traceSpan() {
+    return null;
+  }
+
+  // endregion
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Request.java
@@ -74,6 +74,7 @@ public class FullHttp1Request implements FullRequest {
 
   // region Traceable
 
+  @Nullable
   @Override
   public Span traceSpan() {
     return null;

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp2Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp2Request.java
@@ -1,21 +1,31 @@
 package com.xjeffrose.xio.http.internal;
 
+import brave.Span;
 import com.xjeffrose.xio.http.FullRequest;
 import com.xjeffrose.xio.http.Headers;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http2.Http2Headers;
+import javax.annotation.Nullable;
 
 public class FullHttp2Request implements FullRequest {
 
   private final Http2Headers delegate;
   private final Http2HeadersWrapper headers;
   private final int streamId;
+  private final Span span;
+
+  public FullHttp2Request(Http2Headers delegate, int streamId, @Nullable Span span) {
+    this.delegate = delegate;
+    this.headers = new Http2HeadersWrapper(delegate);
+    this.streamId = streamId;
+    this.span = span;
+  }
 
   public FullHttp2Request(Http2Headers delegate, int streamId) {
-    this.delegate = delegate;
-    headers = new Http2HeadersWrapper(delegate);
-    this.streamId = streamId;
+    this(delegate, streamId, null);
   }
+
+  // region Request
 
   @Override
   public boolean startOfStream() {
@@ -56,4 +66,17 @@ public class FullHttp2Request implements FullRequest {
   public boolean keepAlive() {
     return true;
   }
+
+  // endregion
+
+  // region Traceable
+
+  @Nullable
+  @Override
+  public Span traceSpan() {
+    return span;
+  }
+
+  // endregion
+
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/Http1Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/Http1Request.java
@@ -1,5 +1,6 @@
 package com.xjeffrose.xio.http.internal;
 
+import brave.Span;
 import com.xjeffrose.xio.http.Headers;
 import com.xjeffrose.xio.http.StreamingRequest;
 import io.netty.buffer.ByteBuf;
@@ -7,6 +8,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.ToString;
 
 // TODO(CK): Rename this to StreamingHttp1Request
@@ -17,11 +20,19 @@ public class Http1Request implements StreamingRequest {
 
   protected final HttpRequest delegate;
   private final Http1Headers headers;
+  private final Span span;
 
-  public Http1Request(HttpRequest delegate) {
+  public Http1Request(HttpRequest delegate, @Nullable Span span) {
     this.delegate = delegate;
     headers = new Http1Headers(delegate.headers());
+    this.span = span;
   }
+
+  public Http1Request(HttpRequest delegate) {
+    this(delegate, null);
+  }
+
+  // region Request
 
   @Override
   public boolean startOfStream() {
@@ -62,4 +73,17 @@ public class Http1Request implements StreamingRequest {
   public ByteBuf body() {
     return Unpooled.EMPTY_BUFFER;
   }
+
+  // endregion
+
+  // region Traceable
+
+  @Nonnull
+  @Override
+  public Span traceSpan() {
+    return span;
+  }
+
+  // endregion
+
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/Http1Request.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/Http1Request.java
@@ -8,7 +8,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.ToString;
 
@@ -78,7 +77,7 @@ public class Http1Request implements StreamingRequest {
 
   // region Traceable
 
-  @Nonnull
+  @Nullable
   @Override
   public Span traceSpan() {
     return span;

--- a/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpClientRequestTracingHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpClientRequestTracingHandler.java
@@ -1,11 +1,6 @@
 package com.xjeffrose.xio.tracing;
 
-import brave.Span;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOutboundHandlerAdapter;
-import io.netty.channel.ChannelPromise;
+import io.netty.channel.*;
 import io.netty.handler.codec.http.HttpRequest;
 
 class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapter {
@@ -26,7 +21,7 @@ class HttpClientRequestTracingHandler extends ChannelOutboundHandlerAdapter {
     }
 
     HttpRequest request = (HttpRequest) msg;
-    Span span = state.onRequest(ctx, request);
+    state.onRequest(ctx, request);
 
     ctx.write(msg, promise)
         .addListener(

--- a/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpClientTracingState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpClientTracingState.java
@@ -37,7 +37,7 @@ public class HttpClientTracingState extends HttpTracingState {
     return headers;
   }
 
-  public Span onRequest(ChannelHandlerContext ctx, HttpRequest request) {
+  public void onRequest(ChannelHandlerContext ctx, HttpRequest request) {
     TraceContext parent = popContext(ctx);
     CurrentTraceContext.Scope scope = null;
     if (parent != null) {
@@ -49,8 +49,6 @@ public class HttpClientTracingState extends HttpTracingState {
     if (scope != null) {
       scope.close();
     }
-
-    return span;
   }
 
   public void onResponse(ChannelHandlerContext ctx, HttpResponse response) {

--- a/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpTracingState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/tracing/HttpTracingState.java
@@ -31,6 +31,7 @@ public class HttpTracingState {
     ctx.channel().attr(context_key).set(context);
   }
 
+  // get the context set by outbound request XioRequestEncoder (outbound)
   public static TraceContext popContext(ChannelHandlerContext ctx) {
     return ctx.channel().attr(context_key).getAndSet(null);
   }


### PR DESCRIPTION
adding a `Span` property to the Request interface for trace propagation 