### PR TITLE
wk/taco 131 client h2h1 streamid

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
@@ -8,8 +8,12 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.PromiseCombiner;
+
+import java.net.InetSocketAddress;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
 
 @Slf4j
 public class Client {
@@ -19,7 +23,6 @@ public class Client {
   private final ChannelFutureListener connectionListener;
   private final ChannelFutureListener writeListener;
   private Channel channel;
-  private ChannelFuture connectionFuture;
 
   public Client(ClientState state, Supplier<ChannelHandler> appHandler, XioTracing tracing) {
     this.state = state;
@@ -51,11 +54,15 @@ public class Client {
    * @return A ChannelFuture that succeeds on connect
    */
   public ChannelFuture connect() {
+    return connect(null);
+  }
+
+  public ChannelFuture connect(@Nullable InetSocketAddress address) {
     Bootstrap b = new Bootstrap();
     b.channel(state.channelConfig.channel());
     b.group(state.channelConfig.workerGroup());
     b.handler(clientChannelInitializer);
-    ChannelFuture connectFuture = b.connect(state.remote);
+    ChannelFuture connectFuture = b.connect(address == null ? state.remote : address);
     channel = connectFuture.channel();
     return connectFuture;
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
@@ -8,12 +8,10 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.PromiseCombiner;
-
 import java.net.InetSocketAddress;
 import java.util.function.Supplier;
-import lombok.extern.slf4j.Slf4j;
-
 import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Client {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultFullResponse.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultFullResponse.java
@@ -33,6 +33,11 @@ public abstract class DefaultFullResponse implements FullResponse {
 
   public abstract TraceInfo httpTraceInfo();
 
+  @Override
+  public int streamId() {
+    return Message.H1_STREAM_ID_NONE;
+  }
+
   /** Not intended to be called. */
   @Override
   public String version() {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultSegmentedResponse.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/DefaultSegmentedResponse.java
@@ -19,6 +19,11 @@ public abstract class DefaultSegmentedResponse implements SegmentedResponse {
   public abstract TraceInfo httpTraceInfo();
 
   @Override
+  public int streamId() {
+    return Message.H1_STREAM_ID_NONE;
+  }
+
+  @Override
   public boolean startOfMessage() {
     return true;
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Response.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Response.java
@@ -11,11 +11,6 @@ public interface Response extends Message {
   HttpResponseStatus status();
 
   @Override
-  default int streamId() {
-    return H1_STREAM_ID_NONE;
-  }
-
-  @Override
   default boolean hasBody() {
     return false;
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/SegmentedResponseData.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/SegmentedResponseData.java
@@ -27,6 +27,11 @@ public class SegmentedResponseData implements Response, SegmentedData {
   // region Response
 
   @Override
+  public int streamId() {
+    return response.streamId();
+  }
+
+  @Override
   public HttpResponseStatus status() {
     return response.status();
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Response.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/FullHttp1Response.java
@@ -2,10 +2,12 @@ package com.xjeffrose.xio.http.internal;
 
 import com.xjeffrose.xio.http.FullResponse;
 import com.xjeffrose.xio.http.Headers;
+import com.xjeffrose.xio.http.Message;
 import com.xjeffrose.xio.http.TraceInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import javax.annotation.Nullable;
 
 /** Wrap an incoming FullHttpResponse, for use in a client. */
 public class FullHttp1Response implements FullResponse {
@@ -13,18 +15,25 @@ public class FullHttp1Response implements FullResponse {
   private final FullHttpResponse delegate;
   private final Headers headers;
   private final TraceInfo traceInfo;
+  private final int streamId;
 
-  public FullHttp1Response(FullHttpResponse delegate, TraceInfo traceInfo) {
+  public FullHttp1Response(FullHttpResponse delegate, TraceInfo traceInfo, int streamId) {
     this.delegate = delegate;
     this.headers = new Http1Headers(delegate.headers());
     this.traceInfo = traceInfo == null ? new TraceInfo(headers) : traceInfo;
+    this.streamId = streamId;
   }
 
-  public FullHttp1Response(FullHttpResponse delegate) {
-    this(delegate, null);
+  public FullHttp1Response(FullHttpResponse delegate, @Nullable Integer streamId) {
+    this(delegate, null, streamId == null ? Message.H1_STREAM_ID_NONE : streamId);
   }
 
   // region Response
+
+  @Override
+  public int streamId() {
+    return streamId;
+  }
 
   @Override
   public boolean startOfMessage() {
@@ -36,22 +45,27 @@ public class FullHttp1Response implements FullResponse {
     return true;
   }
 
+  @Override
   public HttpResponseStatus status() {
     return delegate.status();
   }
 
+  @Override
   public String version() {
     return delegate.protocolVersion().text();
   }
 
+  @Override
   public Headers headers() {
     return headers;
   }
 
+  @Override
   public boolean hasBody() {
     return delegate.content() != null && delegate.content().readableBytes() > 0;
   }
 
+  @Override
   public ByteBuf body() {
     return delegate.content();
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/SegmentedHttp1Response.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/SegmentedHttp1Response.java
@@ -1,12 +1,14 @@
 package com.xjeffrose.xio.http.internal;
 
 import com.xjeffrose.xio.http.Headers;
+import com.xjeffrose.xio.http.Message;
 import com.xjeffrose.xio.http.SegmentedResponse;
 import com.xjeffrose.xio.http.TraceInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import javax.annotation.Nullable;
 import lombok.ToString;
 
 /** Wrap an incoming HttpResponse, for use in a client. */
@@ -16,18 +18,25 @@ public class SegmentedHttp1Response implements SegmentedResponse {
   private final HttpResponse delegate;
   private final Headers headers;
   private final TraceInfo traceInfo;
+  private final int streamId;
 
-  public SegmentedHttp1Response(HttpResponse delegate, TraceInfo traceInfo) {
+  public SegmentedHttp1Response(HttpResponse delegate, TraceInfo traceInfo, int streamId) {
     this.delegate = delegate;
     this.headers = new Http1Headers(delegate.headers());
     this.traceInfo = traceInfo == null ? new TraceInfo(headers) : traceInfo;
+    this.streamId = streamId;
   }
 
-  public SegmentedHttp1Response(HttpResponse delegate) {
-    this(delegate, null);
+  public SegmentedHttp1Response(HttpResponse delegate, @Nullable Integer streamId) {
+    this(delegate, null, streamId == null ? Message.H1_STREAM_ID_NONE : streamId);
   }
 
   // region Response
+
+  @Override
+  public int streamId() {
+    return streamId;
+  }
 
   @Override
   public boolean startOfMessage() {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/internal/SegmentedHttp2Response.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/internal/SegmentedHttp2Response.java
@@ -34,6 +34,11 @@ public class SegmentedHttp2Response implements SegmentedResponse {
   // region Response
 
   @Override
+  public int streamId() {
+    return streamId;
+  }
+
+  @Override
   public boolean startOfMessage() {
     return false;
   }

--- a/xio-core/src/test/java/com/xjeffrose/xio/helpers/TlsHelper.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/helpers/TlsHelper.java
@@ -1,5 +1,6 @@
 package com.xjeffrose.xio.helpers;
 
+import com.typesafe.config.ConfigFactory;
 import com.xjeffrose.xio.SSL.TlsConfig;
 import com.xjeffrose.xio.test.OkHttpUnsafe;
 import java.security.KeyStore;
@@ -7,6 +8,15 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 
 public class TlsHelper {
+
+  /**
+   * Creates a {@link KeyManager[]} for use in the test utility
+   * {@link OkHttpUnsafe#getSslMockWebServer(KeyManager[])}
+   */
+  public static KeyManager[] getKeyManagers() throws Exception {
+    TlsConfig tlsConfig = TlsConfig.fromConfig("xio.tlsConfig", ConfigFactory.load());
+    return getKeyManagers(tlsConfig);
+  }
 
   /**
    * Creates a {@link KeyManager[]} from a {@link TlsConfig} for use in the test utility {@link

--- a/xio-core/src/test/java/com/xjeffrose/xio/helpers/TlsHelper.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/helpers/TlsHelper.java
@@ -10,8 +10,8 @@ import javax.net.ssl.KeyManagerFactory;
 public class TlsHelper {
 
   /**
-   * Creates a {@link KeyManager[]} for use in the test utility
-   * {@link OkHttpUnsafe#getSslMockWebServer(KeyManager[])}
+   * Creates a {@link KeyManager[]} for use in the test utility {@link
+   * OkHttpUnsafe#getSslMockWebServer(KeyManager[])}
    */
   public static KeyManager[] getKeyManagers() throws Exception {
     TlsConfig tlsConfig = TlsConfig.fromConfig("xio.tlsConfig", ConfigFactory.load());

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ClientProxiedRequestTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ClientProxiedRequestTest.java
@@ -1,16 +1,21 @@
 package com.xjeffrose.xio.http;
 
+import static com.xjeffrose.xio.helpers.TlsHelper.getKeyManagers;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+
 import com.typesafe.config.ConfigFactory;
-import com.xjeffrose.xio.SSL.TlsConfig;
 import com.xjeffrose.xio.bootstrap.ChannelConfiguration;
 import com.xjeffrose.xio.bootstrap.ClientChannelConfiguration;
 import com.xjeffrose.xio.client.ClientConfig;
-import static com.xjeffrose.xio.helpers.TlsHelper.getKeyManagers;
 import com.xjeffrose.xio.test.OkHttpUnsafe;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import static io.netty.handler.codec.http.HttpMethod.GET;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Protocol;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -18,12 +23,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 public class ClientProxiedRequestTest extends Assert {
 
@@ -60,28 +59,34 @@ public class ClientProxiedRequestTest extends Assert {
 
   public void testWriteServerPreservesStreamId(boolean h2Server) throws Exception {
     // given an h1 / h2 server supporting
-    mockWebServer.setProtocols(h2Server ? Arrays.asList(Protocol.HTTP_1_1, Protocol.HTTP_2) : Collections.singletonList(Protocol.HTTP_1_1));
+    mockWebServer.setProtocols(
+        h2Server
+            ? Arrays.asList(Protocol.HTTP_1_1, Protocol.HTTP_2)
+            : Collections.singletonList(Protocol.HTTP_1_1));
     mockWebServer.enqueue(new MockResponse());
     mockWebServer.start();
 
     // when we proxy an h2 request with a streamId
     int expectedId = 3;
     Request request =
-      DefaultFullRequest.builder()
-        .method(GET)
-        .path("/v1/canonical/cats/meow")
-        .host("127.0.0.1")
-        .body(Unpooled.EMPTY_BUFFER)
-        .streamId(expectedId)
-        .build();
+        DefaultFullRequest.builder()
+            .method(GET)
+            .path("/v1/canonical/cats/meow")
+            .host("127.0.0.1")
+            .body(Unpooled.EMPTY_BUFFER)
+            .streamId(expectedId)
+            .build();
 
     latch = new CountDownLatch(1);
-    client.connect(new InetSocketAddress(request.host(), mockWebServer.getPort())).addListener((ignored) -> client.write(request));
-    latch.await(1, TimeUnit.SECONDS);
+    client
+        .connect(new InetSocketAddress(request.host(), mockWebServer.getPort()))
+        .addListener((ignored) -> client.write(request));
+    latch.await(10000, TimeUnit.SECONDS);
 
     // then the original h2 stream id is preserved
     assertNotNull("expected a response", testHandler.response);
-    assertEquals("expected the stream id to be preserved", expectedId, testHandler.response.streamId());
+    assertEquals(
+        "expected the stream id to be preserved", expectedId, testHandler.response.streamId());
   }
 
   private class TestHandler extends SimpleChannelInboundHandler<Response> {

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ClientProxiedRequestTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ClientProxiedRequestTest.java
@@ -1,0 +1,104 @@
+package com.xjeffrose.xio.http;
+
+import com.typesafe.config.ConfigFactory;
+import com.xjeffrose.xio.SSL.TlsConfig;
+import com.xjeffrose.xio.bootstrap.ChannelConfiguration;
+import com.xjeffrose.xio.bootstrap.ClientChannelConfiguration;
+import com.xjeffrose.xio.client.ClientConfig;
+import static com.xjeffrose.xio.helpers.TlsHelper.getKeyManagers;
+import com.xjeffrose.xio.test.OkHttpUnsafe;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import okhttp3.Protocol;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ClientProxiedRequestTest extends Assert {
+
+  private Client client;
+  private MockWebServer mockWebServer;
+  private CountDownLatch latch;
+  private TestHandler testHandler;
+
+  @Before
+  public void beforeEach() throws Exception {
+    mockWebServer = OkHttpUnsafe.getSslMockWebServer(getKeyManagers());
+
+    ClientChannelConfiguration channelConfig = ChannelConfiguration.clientConfig(1, "worker");
+    ClientConfig clientConfig = new ClientConfig(ConfigFactory.load().getConfig("xio.baseClient"));
+    ClientState clientState = new ClientState(channelConfig, clientConfig);
+    testHandler = new TestHandler();
+    client = new Client(clientState, () -> testHandler, null);
+  }
+
+  @After
+  public void afterEach() throws Exception {
+    mockWebServer.close();
+  }
+
+  @Test
+  public void testWriteH1ServerPreservesStreamId() throws Exception {
+    testWriteServerPreservesStreamId(false);
+  }
+
+  @Test
+  public void testWriteH2ServerPreservesStreamId() throws Exception {
+    testWriteServerPreservesStreamId(true);
+  }
+
+  public void testWriteServerPreservesStreamId(boolean h2Server) throws Exception {
+    // given an h1 / h2 server supporting
+    mockWebServer.setProtocols(h2Server ? Arrays.asList(Protocol.HTTP_1_1, Protocol.HTTP_2) : Collections.singletonList(Protocol.HTTP_1_1));
+    mockWebServer.enqueue(new MockResponse());
+    mockWebServer.start();
+
+    // when we proxy an h2 request with a streamId
+    int expectedId = 3;
+    Request request =
+      DefaultFullRequest.builder()
+        .method(GET)
+        .path("/v1/canonical/cats/meow")
+        .host("127.0.0.1")
+        .body(Unpooled.EMPTY_BUFFER)
+        .streamId(expectedId)
+        .build();
+
+    latch = new CountDownLatch(1);
+    client.connect(new InetSocketAddress(request.host(), mockWebServer.getPort())).addListener((ignored) -> client.write(request));
+    latch.await(1, TimeUnit.SECONDS);
+
+    // then the original h2 stream id is preserved
+    assertNotNull("expected a response", testHandler.response);
+    assertEquals("expected the stream id to be preserved", expectedId, testHandler.response.streamId());
+  }
+
+  private class TestHandler extends SimpleChannelInboundHandler<Response> {
+
+    Throwable error;
+    Response response;
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Response response) throws Exception {
+      latch.countDown();
+      this.response = response;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable error) throws Exception {
+      latch.countDown();
+      this.error = error;
+    }
+  }
+}

--- a/xio-core/src/test/resources/application.conf
+++ b/xio-core/src/test/resources/application.conf
@@ -253,6 +253,17 @@ xio {
     }
   }
 
+  tlsConfig {
+    include classpath("tls-reference.conf")
+    useSsl = true
+    alpn {
+      supportedProtocols = [
+        "http/1.1",
+        "h2"
+      ]
+    }
+  }
+
   h2BackendServer = ${xio.serverTemplate} {
     name = "testHttpsServer"
     settings {


### PR DESCRIPTION
OK - so we need to preserve the "stream id" of proxied h2 requests when the upstream server is h1 so that the proxy can manage the message session per stream id when transitioning between h2 and h1.