### PR TITLE
Wk/taco 131 proxied h2 to h1 transitions

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ClientCodec.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ClientCodec.java
@@ -62,7 +62,14 @@ public class Http1ClientCodec extends ChannelDuplexHandler {
 
     return getProxyRequestQueue(ctx)
         .currentProxiedH2StreamId()
-        .<Response>map(streamId -> new ProxyResponse(response, streamId))
+        .<Response>map(
+            streamId -> {
+              if (response instanceof SegmentedResponseData) {
+                return new ProxySegmentedResponseData((SegmentedResponseData) response, streamId);
+              } else {
+                return new ProxyResponse(response, streamId);
+              }
+            })
         .orElse(response);
   }
 

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2MessageSession.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2MessageSession.java
@@ -89,6 +89,7 @@ public class Http2MessageSession {
   /**
    * Returns the Request object for the current session (if any).
    *
+   * @param streamId the h2 stream id of the session
    * @return the current Request or null
    */
   @Nullable
@@ -103,6 +104,8 @@ public class Http2MessageSession {
   /**
    * Check if the message session has completed for a given streamId, if so remove the message
    * state.
+   *
+   * @param streamId the h2 stream id of the session
    */
   public void flush(int streamId) {
     MessageMetaState initialRequest = streamIdRequests.get(streamId);

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
@@ -56,12 +56,13 @@ public class Http2To1ProxyRequestQueue {
       boolean shouldWrite =
           currentProxiedH2StreamId().map(id -> id.equals(streamId)).orElse(Boolean.TRUE);
 
+      Queue<PendingRequest> queue =
+          streamQueue.computeIfAbsent(streamId, k -> Queues.newArrayDeque());
+
       if (shouldWrite) {
         log.debug("writing h2-h1 proxy request {}", request);
         ctx.write(request, promise);
       } else {
-        Queue<PendingRequest> queue =
-            streamQueue.computeIfAbsent(streamId, k -> Queues.newArrayDeque());
         log.debug("enqueuing h2-h1 proxy request {}", request);
         queue.offer(new PendingRequest(request, promise));
       }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
@@ -1,0 +1,91 @@
+package com.xjeffrose.xio.http;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+import java.util.Queue;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Http2To1ProxyRequestQueue {
+
+  private LinkedHashMap<Integer, Queue<PendingRequest>> streamQueue = Maps.newLinkedHashMap();
+
+  // region public functions
+
+  public Optional<Integer> currentProxiedH2StreamId() {
+    return streamQueue.keySet().stream().findFirst();
+  }
+
+  public void onResponseDrainNext(ChannelHandlerContext ctx, Response response) {
+    if (response.endOfMessage()) {
+      streamQueue.remove(response.streamId());
+    }
+    nextStreamsQueue()
+        .ifPresent(
+            queue -> {
+              while (!queue.isEmpty()) {
+                PendingRequest pending = queue.remove();
+                if (isEmpty()) {
+                  ctx.writeAndFlush(pending.request, pending.promise);
+                } else {
+                  ctx.write(pending.request, pending.promise);
+                }
+              }
+            });
+  }
+
+  public void onRequestWriteOrEnqueue(
+      ChannelHandlerContext ctx, Integer streamId, Object request, ChannelPromise promise) {
+    if (streamId == null || streamId == Message.H1_STREAM_ID_NONE) {
+      log.debug("writing request {}", request);
+      ctx.write(request, promise);
+    } else {
+      boolean shouldWrite =
+          currentProxiedH2StreamId().map(id -> id.equals(streamId)).orElse(Boolean.TRUE);
+
+      Queue<PendingRequest> queue =
+          streamQueue.computeIfAbsent(streamId, k -> Queues.newArrayDeque());
+      if (!shouldWrite) {
+        log.debug("enqueuing request {}", request);
+        queue.offer(new PendingRequest(request, promise));
+      } else {
+        log.debug("writing request {}", request);
+        ctx.write(request, promise);
+      }
+    }
+  }
+
+  public boolean isEmpty() {
+    return streamQueue
+        .values()
+        .stream()
+        .filter(queue -> !queue.isEmpty())
+        .findFirst()
+        .map(ignored -> Boolean.FALSE)
+        .orElse(Boolean.TRUE);
+  }
+
+  // endregion
+
+  // region private functions
+
+  private Optional<Queue<PendingRequest>> nextStreamsQueue() {
+    return streamQueue.values().stream().filter(queue -> !queue.isEmpty()).findFirst();
+  }
+
+  // endregion
+
+  private static class PendingRequest {
+    final Object request;
+    final ChannelPromise promise;
+
+    public PendingRequest(Object request, ChannelPromise promise) {
+      this.request = request;
+      this.promise = promise;
+    }
+  }
+}

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyBackendHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyBackendHandler.java
@@ -1,27 +1,12 @@
 package com.xjeffrose.xio.http;
 
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-import io.netty.util.AttributeKey;
-import javax.annotation.Nullable;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ProxyBackendHandler extends ChannelDuplexHandler {
-
-  private static AttributeKey<Integer> CHANNEL_STREAM_ID_KEY =
-      AttributeKey.newInstance("xio_channel_stream_id");
-
-  private static void setChannelStreamId(ChannelHandlerContext ctx, int streamId) {
-    ctx.channel().attr(CHANNEL_STREAM_ID_KEY).set(streamId);
-  }
-
-  @Nullable
-  private static Integer getChannelStreamId(ChannelHandlerContext ctx) {
-    return ctx.channel().attr(CHANNEL_STREAM_ID_KEY).get();
-  }
+public class ProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
   private final ChannelHandlerContext frontend;
   private boolean needFlush = false;
@@ -40,20 +25,8 @@ public class ProxyBackendHandler extends ChannelDuplexHandler {
   }
 
   @Override
-  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-      throws Exception {
-    if (msg instanceof Request) {
-      setChannelStreamId(ctx, ((Request) msg).streamId());
-    }
-    ctx.write(msg, promise);
-  }
-
-  @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
     log.debug("RawBackendHandler[{}] channelRead: {}", this, msg);
-    if (msg instanceof Response) {
-      msg = responseWithPreservedStreamId(ctx, (Response) msg);
-    }
     frontend
         .write(msg)
         .addListener(
@@ -89,20 +62,5 @@ public class ProxyBackendHandler extends ChannelDuplexHandler {
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     log.debug("RawBackendHandler[{}] exceptionCaught: {}", this, cause);
     ctx.close();
-  }
-
-  @Nullable
-  public Response responseWithPreservedStreamId(ChannelHandlerContext ctx, Response response) {
-    Integer streamId = getChannelStreamId(ctx);
-    if (streamId != null && streamId != Message.H1_STREAM_ID_NONE) {
-      if (response instanceof FullResponse) {
-        return DefaultFullResponse.from((FullResponse) response).streamId(streamId).build();
-      } else if (response instanceof SegmentedResponse) {
-        return DefaultSegmentedResponse.from((SegmentedResponse) response)
-            .streamId(streamId)
-            .build();
-      }
-    }
-    return response;
   }
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyResponse.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyResponse.java
@@ -1,0 +1,69 @@
+package com.xjeffrose.xio.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public class ProxyResponse implements Response {
+
+  private final Response delegate;
+  private final int streamId;
+
+  public ProxyResponse(Response delegate, int streamId) {
+    this.delegate = delegate;
+    this.streamId = streamId;
+  }
+
+  // region Message
+
+  @Override
+  public boolean startOfMessage() {
+    return delegate.startOfMessage();
+  }
+
+  @Override
+  public boolean endOfMessage() {
+    return delegate.endOfMessage();
+  }
+
+  @Override
+  public String version() {
+    return delegate.version();
+  }
+
+  @Override
+  public Headers headers() {
+    return delegate.headers();
+  }
+
+  @Override
+  public int streamId() {
+    return streamId;
+  }
+
+  @Override
+  public TraceInfo httpTraceInfo() {
+    return delegate.httpTraceInfo();
+  }
+
+  @Override
+  public boolean hasBody() {
+    return delegate.hasBody();
+  }
+
+  @Override
+  public ByteBuf body() {
+    return delegate.body();
+  }
+
+  // endregion
+
+  // region Response
+
+  @Override
+  public HttpResponseStatus status() {
+    return delegate.status();
+  }
+
+  // endregion
+
+}

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxySegmentedResponseData.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxySegmentedResponseData.java
@@ -1,0 +1,27 @@
+package com.xjeffrose.xio.http;
+
+import io.netty.buffer.ByteBuf;
+
+public class ProxySegmentedResponseData extends ProxyResponse implements SegmentedData {
+
+  private SegmentedResponseData delegate;
+
+  public ProxySegmentedResponseData(SegmentedResponseData delegate, int streamId) {
+    super(delegate, streamId);
+    this.delegate = delegate;
+  }
+
+  // region SegmentedData
+
+  @Override
+  public ByteBuf content() {
+    return delegate.content();
+  }
+
+  @Override
+  public Headers trailingHeaders() {
+    return delegate.trailingHeaders();
+  }
+
+  // endregion
+}

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueueTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueueTest.java
@@ -1,0 +1,178 @@
+package com.xjeffrose.xio.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.xjeffrose.xio.http.internal.Http1SegmentedData;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class Http2To1ProxyRequestQueueTest extends Assert {
+
+  @Mock ChannelHandlerContext mockCtx;
+  private Http2To1ProxyRequestQueue subject;
+
+  @Before
+  public void beforeEach() {
+    MockitoAnnotations.initMocks(this);
+    subject = new Http2To1ProxyRequestQueue();
+  }
+
+  @Test
+  public void testInterleavedH2FrontRequests_stateTransitions() {
+    // should start empty
+    assertTrue(subject.isEmpty());
+
+    // the first stream id should write
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1a", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1a"), any());
+    assertTrue(subject.isEmpty());
+
+    // the first stream id should write again
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1b", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1b"), any());
+    assertTrue(subject.isEmpty());
+
+    // subsequent stream ids should be enqueued
+    subject.onRequestWriteOrEnqueue(mockCtx, 5, "request 2a", mock(ChannelPromise.class));
+    verify(mockCtx, never()).write(eq("request 2a"), any());
+    assertFalse(subject.isEmpty());
+
+    // the first stream id should write again
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1c", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1c"), any());
+    assertFalse(subject.isEmpty());
+
+    // when the first stream id response completes
+    assertEquals(3, subject.currentProxiedH2StreamId().orElse(0), 0);
+    Response response =
+        DefaultFullResponse.builder()
+            .headers(new DefaultHeaders())
+            .status(HttpResponseStatus.OK)
+            .body(Unpooled.EMPTY_BUFFER)
+            .streamId(3)
+            .build();
+    subject.onResponseDrainNext(mockCtx, response);
+
+    // then the subsequent stream ids should write
+    verify(mockCtx).writeAndFlush(eq("request 2a"), any());
+    assertSame(response, subject.currentResponse().orElse(null));
+
+    // and the stream id should be correct
+    assertEquals(5, subject.currentProxiedH2StreamId().orElse(0), 0);
+
+    // and the the queue should be empty
+    assertTrue(subject.isEmpty());
+  }
+
+  @Test
+  public void testInterleavedH2FrontRequestsSegmentedResponse_stateTransitions() {
+    // should start empty
+    assertTrue(subject.isEmpty());
+
+    // the first stream id should write
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1a", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1a"), any());
+    assertTrue(subject.isEmpty());
+
+    // the first stream id should write again
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1b", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1b"), any());
+    assertTrue(subject.isEmpty());
+
+    // subsequent stream ids should be enqueued (and not written)
+    subject.onRequestWriteOrEnqueue(mockCtx, 5, "request 2a", mock(ChannelPromise.class));
+    verify(mockCtx, never()).write(eq("request 2a"), any());
+    assertFalse(subject.isEmpty());
+
+    // the first stream id should write again
+    subject.onRequestWriteOrEnqueue(mockCtx, 3, "request 1c", mock(ChannelPromise.class));
+    verify(mockCtx).write(eq("request 1c"), any());
+    assertFalse(subject.isEmpty());
+
+    // subsequent stream ids should be enqueued (and not written)
+    subject.onRequestWriteOrEnqueue(mockCtx, 5, "request 2b", mock(ChannelPromise.class));
+    verify(mockCtx, never()).write(eq("request 2b"), any());
+    assertFalse(subject.isEmpty());
+
+    //////////// when the first stream id responses occur
+    assertEquals(3, subject.currentProxiedH2StreamId().orElse(0), 0);
+    Response stream3Response0 =
+        DefaultSegmentedResponse.builder()
+            .headers(new DefaultHeaders())
+            .status(HttpResponseStatus.OK)
+            .streamId(3)
+            .build();
+
+    subject.onResponseDrainNext(mockCtx, stream3Response0);
+    assertSame(stream3Response0, subject.currentResponse().orElse(null));
+    verifyNoMoreInteractions(mockCtx); // should not write anything queued
+
+    Response stream3Response1 =
+        new SegmentedResponseData(
+            stream3Response0,
+            new Http1SegmentedData(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+
+    subject.onResponseDrainNext(mockCtx, stream3Response1);
+    assertSame(stream3Response0, subject.currentResponse().orElse(null));
+    verifyNoMoreInteractions(mockCtx); // should not write anything queued
+
+    // when the first stream id responses complete
+    Response stream3Response2 =
+        new SegmentedResponseData(
+            stream3Response0,
+            new Http1SegmentedData(new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER)));
+
+    subject.onResponseDrainNext(mockCtx, stream3Response2);
+    assertSame(stream3Response0, subject.currentResponse().orElse(null));
+
+    // then the second stream's enqueued requests should spool out
+    verify(mockCtx).write(eq("request 2a"), any()); // should write stream 5 requests
+    verify(mockCtx).writeAndFlush(eq("request 2b"), any()); // should write stream 5 requests
+
+    //////////// when the second stream id responses occur
+
+    assertEquals(5, subject.currentProxiedH2StreamId().orElse(0), 0);
+    Response stream5Response0 =
+        DefaultSegmentedResponse.builder()
+            .headers(new DefaultHeaders())
+            .status(HttpResponseStatus.OK)
+            .streamId(5)
+            .build();
+
+    subject.onResponseDrainNext(mockCtx, stream5Response0);
+    assertSame(stream5Response0, subject.currentResponse().orElse(null));
+
+    Response stream5Response1 =
+        new SegmentedResponseData(
+            stream5Response0,
+            new Http1SegmentedData(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+
+    subject.onResponseDrainNext(mockCtx, stream5Response1);
+    assertSame(stream5Response0, subject.currentResponse().orElse(null));
+
+    Response stream5Response2 =
+        new SegmentedResponseData(
+            stream5Response0,
+            new Http1SegmentedData(new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER)));
+
+    subject.onResponseDrainNext(mockCtx, stream5Response2);
+    assertSame(stream5Response0, subject.currentResponse().orElse(null));
+
+    // and the the queue should be empty
+    assertTrue(subject.isEmpty());
+  }
+}

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
@@ -42,7 +42,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -272,7 +271,6 @@ public class ReverseProxyFunctionalTest extends Assert {
     post(port(), false, HTTP_1_1);
   }
 
-  @Ignore("WBK - TACO-131 spoon feed proxied h2 front to h1 back")
   @Test
   public void testHttp2toHttp1ServerGetMany() throws Exception {
     setupClient(true);
@@ -289,7 +287,6 @@ public class ReverseProxyFunctionalTest extends Assert {
     requests(iterations, false);
   }
 
-  @Ignore("WBK - TACO-131 spoon feed proxied h2 front to h1 back")
   @Test
   public void testHttp2toHttp1ServerPostMany() throws Exception {
     setupClient(true);

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
@@ -289,6 +289,7 @@ public class ReverseProxyFunctionalTest extends Assert {
     requests(iterations, false);
   }
 
+  @Ignore("WBK - TACO-131 spoon feed proxied h2 front to h1 back")
   @Test
   public void testHttp2toHttp1ServerPostMany() throws Exception {
     setupClient(true);
@@ -297,7 +298,6 @@ public class ReverseProxyFunctionalTest extends Assert {
     requests(iterations, true);
   }
 
-  @Ignore("WBK - TACO-131 spoon feed proxied h2 front to h1 back")
   @Test
   public void testHttp2toHttp2ServerPostMany() throws Exception {
     setupClient(true);

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
@@ -325,7 +325,8 @@ public class ReverseProxyFunctionalTest extends Assert {
                   }
                   Response response = client.newCall(request.build()).execute();
                   responses.offer(response);
-                } catch (IOException ignored) {
+                } catch (IOException error) {
+                  error.printStackTrace();
                 } finally {
                   latch.countDown();
                 }


### PR DESCRIPTION
* these changes address proxy requests where the front is h2 and back is h1
* the first change is tracking the h2 request stream id and propagating it to the ProxyResponse
* the second change is queuing subsequent h2 stream ids until the first stream id completes
(this is not ideal - ideally we would make a new h1 connection)