### PR TITLE
TACO-162 - fixing h2 to h1 proxy

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
@@ -19,7 +19,6 @@ public class Client {
   private final ChannelFutureListener connectionListener;
   private final ChannelFutureListener writeListener;
   private Channel channel;
-  private ChannelFuture connectionFuture;
 
   public Client(ClientState state, Supplier<ChannelHandler> appHandler, XioTracing tracing) {
     this.state = state;

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2To1ProxyRequestQueue.java
@@ -35,7 +35,7 @@ public class Http2To1ProxyRequestQueue {
                 while (!queue.isEmpty()) {
                   PendingRequest pending = queue.remove();
                   log.debug("writing enqueued h2-h1 proxy request {}", pending.request);
-                  if (isEmpty()) {
+                  if (queue.isEmpty()) {
                     ctx.writeAndFlush(pending.request, pending.promise);
                   } else {
                     ctx.write(pending.request, pending.promise);

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ReverseProxyFunctionalTest.java
@@ -297,7 +297,6 @@ public class ReverseProxyFunctionalTest extends Assert {
   }
 
   @Test
-  @Ignore("todo: WBK - land of the misfit toys")
   public void testHttp2toHttp1ServerGetMany() throws Exception {
     setupClient(true);
     setupFrontBack(true, false);
@@ -312,7 +311,6 @@ public class ReverseProxyFunctionalTest extends Assert {
   }
 
   @Test
-  @Ignore("todo: WBK - land of the misfit toys")
   public void testHttp2toHttp1ServerPostMany() throws Exception {
     setupClient(true);
     setupFrontBack(true, false);


### PR DESCRIPTION
ok - i should have seen this earlier - h2 to h1 transition is now fully functional