### PR TITLE
Wk/taco 20 reduce reuse recycle

### DIFF
--- a/xio-core/build.gradle
+++ b/xio-core/build.gradle
@@ -82,7 +82,7 @@ dependencies {
   }
   testImplementation group: 'io.grpc', name: 'grpc-protobuf', version: grpc_version
   testImplementation group: 'io.grpc', name: 'grpc-stub', version: grpc_version
-  testImplementation group: 'org.mortbay.jetty.alpn', name: 'alpn-boot', version: alpn_boot_version
+  testCompile group: 'org.mortbay.jetty.alpn', name: 'alpn-boot', version: alpn_boot_version
 }
 
 test {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientPool.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientPool.java
@@ -27,6 +27,8 @@ public class ClientPool {
   }
 
   public void release(Client client) {
+    log.debug("recycling client {}", client);
+    client.recycle();
     ConcurrentMap<Client, Meta> pool = getPool(client.remoteAddress());
     if (pool.size() < maxSizePerAddress && !pool.containsKey(client)) {
       log.debug("releasing client to pool {}", client);
@@ -38,8 +40,6 @@ public class ClientPool {
         meta.available.set(true);
       }
     }
-    log.debug("recycling client {}", client);
-    client.recycle();
   }
 
   @VisibleForTesting

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2ClientStreamMapper.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2ClientStreamMapper.java
@@ -45,7 +45,11 @@ public class Http2ClientStreamMapper {
       mappedId = streamMap.inverse().get(id);
       log.debug("h2 client inbound stream id {} : {}", id, mappedId);
     }
-    return mappedId == null ? id : mappedId;
+    if (mappedId == null) {
+      log.error("h2 client inbound stream id {} : XXX", id);
+      mappedId = id;
+    }
+    return mappedId;
   }
 
   public void clear() {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http2ClientStreamMapper.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http2ClientStreamMapper.java
@@ -5,7 +5,9 @@ import com.google.common.collect.HashBiMap;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.util.AttributeKey;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class Http2ClientStreamMapper {
 
   static final AttributeKey<Http2ClientStreamMapper> H2_CLIENT_STREAM_MAPPER =
@@ -28,6 +30,7 @@ public class Http2ClientStreamMapper {
     Integer mappedId = streamMap.get(id);
     if (mappedId == null) {
       mappedId = connection.local().incrementAndGetNextStreamId();
+      log.debug("h2 client outbound stream id {} : {}", id, mappedId);
       streamMap.put(id, mappedId);
     }
     return mappedId;
@@ -37,13 +40,16 @@ public class Http2ClientStreamMapper {
     Integer mappedId;
     if (remove) {
       mappedId = streamMap.inverse().remove(id);
+      log.debug("h2 client inbound stream id {} : {}", id, mappedId);
     } else {
       mappedId = streamMap.inverse().get(id);
+      log.debug("h2 client inbound stream id {} : {}", id, mappedId);
     }
     return mappedId == null ? id : mappedId;
   }
 
   public void clear() {
+    log.debug("h2 client stream mapping clear");
     streamMap.clear();
   }
 }


### PR DESCRIPTION
clearing the Client stream mapping **before** atomically setting available in the pool
ProxyBackendHandler `writeAndFlush` when message is eos
