### PR TITLE
TACO-151-ec2-launch-script added a launch script for the int-test-bac…

### DIFF
--- a/int-test-backend-server/scripts/launchOnEC2.sh
+++ b/int-test-backend-server/scripts/launchOnEC2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/home/admin/app/int-test-backend-server-0.13.9-SNAPSHOT/bin/int-test-backend-server $(curl http://169.254.169.254/latest/meta-data/local-ipv4) 8080 $(curl http://169.254.169.254/latest/meta-data/local-ipv4)

--- a/int-test-backend-server/scripts/spinup.sh
+++ b/int-test-backend-server/scripts/spinup.sh
@@ -14,7 +14,7 @@ SUBNET=$6
 # $PROFILE example is nordstrom-federated
 aws autoscaling create-launch-configuration --launch-configuration-name $NAME \
   --image-id $AMI --key-name $KEY --security-groups $SG --instance-type t2.micro \
-  --region us-west-2 --profile $PROFILE
+  --region us-west-2 --profile $PROFILE --user-data file://./launchOnEC2.sh
 
 # Spin up the ASG
 aws autoscaling create-auto-scaling-group --auto-scaling-group-name $NAME \


### PR DESCRIPTION
TACO-151-ec2-launch-script added a launch script for the int-test-backup-server ec2 instances to use to start listenting on port 8080 on any route