### PR TITLE
Wk/taco 231 fix client pool

### DIFF
--- a/int-test-proxy-server/src/main/resources/logback.groovy
+++ b/int-test-proxy-server/src/main/resources/logback.groovy
@@ -19,8 +19,10 @@ logger("io.netty.util.internal.PlatformDependent0", OFF)
 logger("io.netty.handler.ssl.CipherSuiteConverter", OFF)
 
 
-if (System.getProperty("COVERAGE") != null) {
+if (System.getProperty("DEBUG") != null) {
+  root(DEBUG, ["CONSOLE"])
+} else if (System.getProperty("COVERAGE") != null) {
   root(DEBUG, ["DEVNULL"])
 } else {
-  root(DEBUG, ["CONSOLE"])
+  root(WARN, ["CONSOLE"])
 }

--- a/int-tests/server_controller.py
+++ b/int-tests/server_controller.py
@@ -70,7 +70,7 @@ class Server:
       argv = str(args[0]).strip()
     else:
       argv = ''
-    self.cmd = "{} {} {} {} {}".format(script, host, self.port, self.name, argv)
+    self.cmd = ' '.join("{} {} {} {} {}".format(script, host, self.port, self.name, argv).split())
     self.process = None
     self.ready_str = ready_str
 
@@ -84,7 +84,7 @@ class Server:
 
   def run(self):
     if self.process is None:
-      print("server start cmd: {}".format(self.cmd))
+      print("server {} run cmd: {}".format(self.name, self.cmd))
       env = {**os.environ, 'JAVA_OPTS': '-DDEBUG=1'}
       self.process = subprocess.Popen("exec " + self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=env)
       nb_err = StdOutReader(self.process.stderr, verbose=self._verbose)
@@ -95,5 +95,6 @@ class Server:
     return self
 
   def kill(self):
+    print("server {} killed".format(self.name))
     if self.process is not None:
       self.process.kill()

--- a/int-tests/server_controller.py
+++ b/int-tests/server_controller.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import functools
+import os
 import os.path as path
 from threading import Thread
 from queue import Queue, Empty
@@ -84,7 +85,8 @@ class Server:
   def run(self):
     if self.process is None:
       print("server start cmd: {}".format(self.cmd))
-      self.process = subprocess.Popen("exec " + self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+      env = {**os.environ, 'JAVA_OPTS': '-DDEBUG=1'}
+      self.process = subprocess.Popen("exec " + self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=env)
       nb_err = StdOutReader(self.process.stderr, verbose=self._verbose)
       nb_out = StdOutReader(self.process.stdout, verbose=self._verbose)
       while True:

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Client.java
@@ -101,12 +101,13 @@ public class Client {
   public void prepareForReuse(Supplier<ChannelHandler> handlerSupplier) {
     clientChannelInitializer.setAppHandler(handlerSupplier);
     if (channel != null) {
-      channel.pipeline().replace("app handler", "app handler", handlerSupplier.get());
+      channel.pipeline().addLast(ClientChannelInitializer.APP_HANDLER, handlerSupplier.get());
     }
   }
 
   public void recycle() {
     if (channel != null) {
+      channel.pipeline().remove(ClientChannelInitializer.APP_HANDLER);
       Http2ClientStreamMapper.http2ClientStreamMapper(channel.pipeline().firstContext()).clear();
     }
   }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
@@ -9,12 +9,13 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.handler.codec.http.HttpServerCodec;
 import java.util.function.Supplier;
+import lombok.Setter;
 import lombok.val;
 
 public class ClientChannelInitializer extends ChannelInitializer {
 
   private final ClientState state;
-  private final Supplier<ChannelHandler> appHandler;
+  @Setter private Supplier<ChannelHandler> appHandler;
   private final XioTracing tracing;
 
   public ClientChannelInitializer(

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
@@ -14,6 +14,8 @@ import lombok.val;
 
 public class ClientChannelInitializer extends ChannelInitializer {
 
+  public static final String APP_HANDLER = "app handler";
+
   private final ClientState state;
   @Setter private Supplier<ChannelHandler> appHandler;
   private final XioTracing tracing;
@@ -65,6 +67,6 @@ public class ClientChannelInitializer extends ChannelInitializer {
         .addLast("idle handler", new XioIdleDisconnectHandler(60, 60, 60))
         .addLast("message logging", new XioMessageLogger(Client.class, "objects"))
         .addLast("request buffer", new RequestBuffer())
-        .addLast("app handler", appHandler.get());
+        .addLast(APP_HANDLER, appHandler.get());
   }
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientFactory.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientFactory.java
@@ -37,8 +37,12 @@ public abstract class ClientFactory {
         .orElseGet(
             () -> {
               Client client = createClient(ctx, config);
-              ctx.channel().attr(CLIENT_KEY).set(client);
+              updateChannelAttr(ctx, client);
               return client;
             });
+  }
+
+  public void updateChannelAttr(ChannelHandlerContext ctx, Client client) {
+    ctx.channel().attr(CLIENT_KEY).set(client);
   }
 }

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyClientFactory.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyClientFactory.java
@@ -29,7 +29,10 @@ public class ProxyClientFactory extends ClientFactory {
 
   @Override
   public Client getClient(ChannelHandlerContext ctx, ClientConfig config) {
-    return getHandlerClient(ctx)
-        .orElse(clientPool.acquire(config, () -> super.getClient(ctx, config)));
+    Client client =
+        getHandlerClient(ctx)
+            .orElse(clientPool.acquire(ctx, config, () -> createClient(ctx, config)));
+    updateChannelAttr(ctx, client);
+    return client;
   }
 }


### PR DESCRIPTION
* fixed the client pool by swapping out the channel handler associated with the front-end when reusing a recycled client

There were 2 problems:
1 (found by @khappucino ) clients acquired by the pool were not being attached to the channel handler ctx
2 the client "app handler" (ProxyBackendHandler) was associated with the original front-end channel on pooled clients