### PR TITLE
TACO-326-supreme removing the idle channel handler from the ClientCha…

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/client/ClientConfig.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/client/ClientConfig.java
@@ -14,12 +14,14 @@ import lombok.extern.slf4j.Slf4j;
 @Accessors(fluent = true)
 @Getter
 public class ClientConfig {
+
   private final Map<ChannelOption<Object>, Object> bootstrapOptions;
   private final String name;
   private final TlsConfig tls;
   private final boolean messageLoggerEnabled;
   private final InetSocketAddress local;
   private final InetSocketAddress remote;
+  private final IdleTimeoutConfig idleTimeoutConfig;
 
   public String getName() {
     return name;
@@ -48,11 +50,22 @@ public class ClientConfig {
       local = new InetSocketAddress(config.getString("localIp"), config.getInt("localPort"));
     }
     remote = new InetSocketAddress(config.getString("remoteIp"), config.getInt("remotePort"));
+
+    boolean idleTimeoutEnabled = config.getBoolean("idleTimeoutEnabled");
+    int idleTimeoutDuration = 0;
+    if (idleTimeoutEnabled) {
+      idleTimeoutDuration = config.getInt("idleTimeoutDuration");
+    }
+    idleTimeoutConfig = new IdleTimeoutConfig(idleTimeoutEnabled, idleTimeoutDuration);
   }
 
   public boolean isTlsEnabled() {
     return tls.isUseSsl();
   }
+
+  public IdleTimeoutConfig getIdleTimeoutConfig() {
+    return idleTimeoutConfig;
+  };
 
   public static ClientConfig fromConfig(String key, Config config) {
     return new ClientConfig(config.getConfig(key));

--- a/xio-core/src/main/java/com/xjeffrose/xio/client/IdleTimeoutConfig.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/client/IdleTimeoutConfig.java
@@ -1,0 +1,11 @@
+package com.xjeffrose.xio.client;
+
+public class IdleTimeoutConfig {
+  public final boolean enabled;
+  public final int duration;
+
+  public IdleTimeoutConfig(boolean enabled, int duration) {
+    this.enabled = enabled;
+    this.duration = duration;
+  }
+}

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
@@ -1,6 +1,5 @@
 package com.xjeffrose.xio.http;
 
-import com.xjeffrose.xio.core.XioIdleDisconnectHandler;
 import com.xjeffrose.xio.core.XioMessageLogger;
 import com.xjeffrose.xio.pipeline.Pipelines;
 import com.xjeffrose.xio.tracing.XioTracing;
@@ -64,7 +63,6 @@ public class ClientChannelInitializer extends ChannelInitializer {
     }
     channel
         .pipeline()
-        .addLast("idle handler", new XioIdleDisconnectHandler(60, 60, 60))
         .addLast("message logging", new XioMessageLogger(Client.class, "objects"))
         .addLast("request buffer", new RequestBuffer())
         .addLast(APP_HANDLER, appHandler.get());

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientChannelInitializer.java
@@ -1,5 +1,6 @@
 package com.xjeffrose.xio.http;
 
+import com.xjeffrose.xio.core.XioIdleDisconnectHandler;
 import com.xjeffrose.xio.core.XioMessageLogger;
 import com.xjeffrose.xio.pipeline.Pipelines;
 import com.xjeffrose.xio.tracing.XioTracing;
@@ -61,6 +62,14 @@ public class ClientChannelInitializer extends ChannelInitializer {
       val traceHandler = tracing.newClientHandler(state.config.isTlsEnabled());
       Pipelines.addHandler(channel.pipeline(), "distributed tracing", traceHandler);
     }
+
+    if (state.idleTimeoutEnabled) {
+      int duration = state.idleTimeoutDuration;
+      channel
+          .pipeline()
+          .addLast("idle handler", new XioIdleDisconnectHandler(duration, duration, duration));
+    }
+
     channel
         .pipeline()
         .addLast("message logging", new XioMessageLogger(Client.class, "objects"))

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ClientState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ClientState.java
@@ -13,6 +13,8 @@ public class ClientState {
   public final ClientConfig config;
   public final InetSocketAddress remote;
   public final SslContext sslContext;
+  public final boolean idleTimeoutEnabled;
+  public final int idleTimeoutDuration;
 
   private static SslContext sslContext(boolean enableTls, ClientConfig clientConfig) {
     if (enableTls) {
@@ -31,6 +33,8 @@ public class ClientState {
     this.config = config;
     this.remote = remote;
     this.sslContext = sslContext;
+    idleTimeoutEnabled = config.getIdleTimeoutConfig().enabled;
+    idleTimeoutDuration = config.getIdleTimeoutConfig().duration;
   }
 
   public ClientState(
@@ -42,9 +46,6 @@ public class ClientState {
   }
 
   public ClientState(ClientChannelConfiguration channelConfig, ClientConfig config) {
-    this.channelConfig = channelConfig;
-    this.config = config;
-    this.remote = config.remote();
-    this.sslContext = sslContext(config.isTlsEnabled(), config);
+    this(channelConfig, config, config.remote(), sslContext(config.isTlsEnabled(), config));
   }
 }

--- a/xio-core/src/main/resources/reference.conf
+++ b/xio-core/src/main/resources/reference.conf
@@ -163,6 +163,8 @@ xio {
     remotePort = 0
     localIp = ""
     localPort = 0
+    idleTimeoutEnabled = false
+    idleTimeoutDuration = 0
     settings {
       messageLoggerEnabled = true
       tls {

--- a/xio-core/src/test/resources/application.conf
+++ b/xio-core/src/test/resources/application.conf
@@ -337,6 +337,7 @@ xio {
       }
     }
   }
+
   sslClient = ${xio.clientTemplate} {
     name = sslClient
     settings {
@@ -345,6 +346,19 @@ xio {
       }
     }
   }
+
+  idleDisabledClient = ${xio.clientTemplate} {
+    name = basicClient
+    idleTimeoutEnabled = false
+    idleTimeoutDuration = 0
+  }
+
+  idleEnabledClient = ${xio.clientTemplate} {
+    name = basicClient
+    idleTimeoutEnabled = true
+    idleTimeoutDuration = 60
+  }
+
   invalidZipkinParameters = ${xio.clientTemplate} {
     name = invalidZipkinParameters
     settings {


### PR DESCRIPTION
…nnelInitializer so that we don't manually close the channel just because it is idling, we are trying to keep the client channels open so when we reuse the client we don't have to do the whole handshake over again to connect