### PR TITLE
br/TACO-236: added getter for applogic on grpc handler

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/GrpcRequestHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/GrpcRequestHandler.java
@@ -94,6 +94,10 @@ public class GrpcRequestHandler<
     this.appLogic = appLogic;
   }
 
+  public Function<GrpcRequest, GrpcResponse> getAppLogic() {
+    return appLogic;
+  }
+
   @Override
   public void handle(ChannelHandlerContext ctx, Request request, RouteState route) {
     ByteBuf actualBuffer;

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcRequestHandlerTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcRequestHandlerTest.java
@@ -12,6 +12,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.function.Function;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +40,14 @@ public class GrpcRequestHandlerTest extends Assert {
                 subject.handle(ctx, request, null);
               }
             });
+  }
+
+  @Test
+  public void testGetAppLogic() {
+    Function<HelloRequest, HelloReply> expectedAppLogic = (HelloRequest request) -> HelloReply.getDefaultInstance();
+    GrpcRequestHandler handler = new GrpcRequestHandler<>(HelloRequest::parseFrom, expectedAppLogic);
+
+    assertSame(expectedAppLogic, handler.getAppLogic());
   }
 
   @Test

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcRequestHandlerTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcRequestHandlerTest.java
@@ -13,7 +13,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.function.Function;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,8 +43,10 @@ public class GrpcRequestHandlerTest extends Assert {
 
   @Test
   public void testGetAppLogic() {
-    Function<HelloRequest, HelloReply> expectedAppLogic = (HelloRequest request) -> HelloReply.getDefaultInstance();
-    GrpcRequestHandler handler = new GrpcRequestHandler<>(HelloRequest::parseFrom, expectedAppLogic);
+    Function<HelloRequest, HelloReply> expectedAppLogic =
+        (HelloRequest request) -> HelloReply.getDefaultInstance();
+    GrpcRequestHandler handler =
+        new GrpcRequestHandler<>(HelloRequest::parseFrom, expectedAppLogic);
 
     assertSame(expectedAppLogic, handler.getAppLogic());
   }


### PR DESCRIPTION
This allows users of xio (i.e. nfe) to test created GrpcRequestHandlers without having to parse gRPC bits