### PR TITLE
Wk/taco 378 preserve explicitly set transfer-encoding header

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ServerCodec.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ServerCodec.java
@@ -11,19 +11,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.DefaultHttpContent;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.EmptyHttpHeaders;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.netty.util.AttributeKey;
 import lombok.extern.slf4j.Slf4j;
 
@@ -134,18 +122,19 @@ public class Http1ServerCodec extends ChannelDuplexHandler {
                 full.headers().http1Headers(false, false),
                 EmptyHttpHeaders.INSTANCE);
       } else {
-        // TODO(CK): TransferEncoding
         // We don't know the size of the message payload so set TransferEncoding to chunked
+        HttpHeaders headers = response.headers().http1Headers(false, false);
         if (!response.headers().contains(HttpHeaderNames.TRANSFER_ENCODING)) {
-          response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-          response.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+          headers.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+          headers.remove(HttpHeaderNames.CONTENT_LENGTH);
         }
 
         obj =
             new DefaultHttpResponse(
                 HttpVersion.HTTP_1_1,
                 response.status(),
-                response.headers().http1Headers(false, false));
+                headers
+                );
       }
 
       ChannelFuture future = ctx.write(obj, promise);

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ServerCodec.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/Http1ServerCodec.java
@@ -129,12 +129,7 @@ public class Http1ServerCodec extends ChannelDuplexHandler {
           headers.remove(HttpHeaderNames.CONTENT_LENGTH);
         }
 
-        obj =
-            new DefaultHttpResponse(
-                HttpVersion.HTTP_1_1,
-                response.status(),
-                headers
-                );
+        obj = new DefaultHttpResponse(HttpVersion.HTTP_1_1, response.status(), headers);
       }
 
       ChannelFuture future = ctx.write(obj, promise);

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/Http1ServerCodecUnitTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/Http1ServerCodecUnitTest.java
@@ -15,12 +15,10 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.*;
-
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -242,7 +240,9 @@ public class Http1ServerCodecUnitTest extends Assert {
     assertEquals(body2, bodyOut2.content());
 
     // https://tools.ietf.org/html/rfc7230#section-3.3.2
-    assertEquals(HttpHeaderValues.CHUNKED.toString(), responseOut.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+    assertEquals(
+        HttpHeaderValues.CHUNKED.toString(),
+        responseOut.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
     assertNull(responseOut.headers().get(HttpHeaderNames.CONTENT_LENGTH));
   }
 
@@ -255,17 +255,17 @@ public class Http1ServerCodecUnitTest extends Assert {
 
     Headers headers = new Http2HeadersWrapper(new DefaultHttp2Headers());
     SegmentedResponse responseIn =
-      DefaultSegmentedResponse.builder().status(OK).headers(headers).build();
+        DefaultSegmentedResponse.builder().status(OK).headers(headers).build();
     ByteBuf body1 = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, "body1");
     SegmentedData content =
-      DefaultSegmentedData.builder().content(body1).endOfMessage(false).build();
+        DefaultSegmentedData.builder().content(body1).endOfMessage(false).build();
     ByteBuf body2 = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, "body2");
     SegmentedData lastContent =
-      DefaultSegmentedData.builder()
-        .content(body2)
-        .endOfMessage(true)
-        .trailingHeaders(new DefaultHeaders())
-        .build();
+        DefaultSegmentedData.builder()
+            .content(body2)
+            .endOfMessage(true)
+            .trailingHeaders(new DefaultHeaders())
+            .build();
 
     channel.writeInbound(requestIn);
     channel.runPendingTasks(); // blocks
@@ -279,9 +279,10 @@ public class Http1ServerCodecUnitTest extends Assert {
 
     HttpResponse responseOut = (HttpResponse) responses.remove(0);
 
-
     // https://tools.ietf.org/html/rfc7230#section-3.3.2
-    assertEquals(HttpHeaderValues.CHUNKED.toString(), responseOut.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+    assertEquals(
+        HttpHeaderValues.CHUNKED.toString(),
+        responseOut.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
     assertNull(responseOut.headers().get(HttpHeaderNames.CONTENT_LENGTH));
   }
 }


### PR DESCRIPTION
preserve explicitly set transfer-encoding header for proxied h2 to h1 requests