### PR TITLE
TACO-383 - exercise PersistentProxyHandler in integration tests

### DIFF
--- a/int-test-proxy-server/docker-app.conf
+++ b/int-test-proxy-server/docker-app.conf
@@ -62,6 +62,15 @@ xio {
     name = "test client"
     remotePort = 443
     remoteIp = "back"
+    settings {
+      tls {
+        x509TrustedCertPaths = [
+          "classpath:xio-default-snakeoil-ca-x509.pem"
+          "classpath:xio-default-snakeoil-intermediate-x509.pem"
+          "classpath:xrpc-pub-cert.pem"
+        ]
+      }
+    }
   }
 
   testProxyRoute = ${xio.routeTemplate} {

--- a/int-test-proxy-server/src/main/java/com/xjeffrose/xio/proxy/RouteStates.java
+++ b/int-test-proxy-server/src/main/java/com/xjeffrose/xio/proxy/RouteStates.java
@@ -1,0 +1,40 @@
+package com.xjeffrose.xio.proxy;
+
+import com.google.common.collect.ImmutableMap;
+import com.xjeffrose.xio.application.ApplicationState;
+import com.xjeffrose.xio.core.SocketAddressHelper;
+import com.xjeffrose.xio.http.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RouteStates {
+  private final AtomicReference<ImmutableMap<String, RouteState>> routeMap;
+
+  public RouteStates(
+      ProxyRouteConfig proxyRouteConfig,
+      ApplicationState applicationState,
+      ProxyClientFactory clientFactory) {
+    List<ProxyRouteState> proxyRouteStates =
+        Stream.of(proxyRouteConfig)
+            .map(
+                (ProxyRouteConfig config) ->
+                    new ProxyRouteState(
+                        applicationState,
+                        config,
+                        new PersistentProxyHandler(
+                            clientFactory, config, new SocketAddressHelper())))
+            .collect(Collectors.toList());
+
+    LinkedHashMap<String, ProxyRouteState> routeMap = new LinkedHashMap<>();
+    proxyRouteStates.forEach((ProxyRouteState state) -> routeMap.put(state.path(), state));
+
+    this.routeMap = new AtomicReference<>(ImmutableMap.copyOf(routeMap));
+  }
+
+  public ImmutableMap<String, RouteState> routeMap() {
+    return routeMap.get();
+  }
+}

--- a/int-tests/README.md
+++ b/int-tests/README.md
@@ -26,3 +26,35 @@ Note: Any java changes will be recompiled before the tests are run.
 ```bash
 ./container_tests.sh
 ```
+
+# Containerized Tests (Running Manually)
+
+```
+# Build servers 
+./gradlew :int-test-proxy-server:installDist && ./gradlew :int-test-backend-server:installDist
+
+# Build docker images 
+cd int-tests && docker-compose build
+
+# Run client and and servers in docker
+docker-compose run client /bin/bash
+
+# Run tests in docker client container
+python3 /tests/proxy_load_tests.py
+
+# Run wrk, curl, h2load etc
+curl -kv https://back/
+curl -kv https://front/
+wrk -t4 -c400 -d30s https://front/
+h2load -t4 -c400 -D30 https://front/
+
+# Exit docker client container
+exit
+
+# Stop docker containers
+docker-compose stop
+```
+
+
+
+

--- a/int-tests/docker-compose.yml
+++ b/int-tests/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         condition: service_healthy
       front:
         condition: service_healthy
+#    stdin_open: true # docker-compose run client /bin/bash
+#    tty: true
     command: ["python3", "/tests/proxy_load_tests.py"]
     links:
       - front
@@ -24,10 +26,10 @@ services:
     ports:
       - "8444:443"
     healthcheck:
-      test: ["CMD", "curl", "-f", "-k", "https://localhost"]
+      test: ["CMD", "curl", "-m", "1", "-f", "-k", "https://localhost"]
       interval: 1s
       timeout: 3s
-      retries: 60
+      retries: 10
 
   front:
     build:
@@ -39,7 +41,7 @@ services:
     ports:
       - "8443:443"
     healthcheck:
-      test: ["CMD", "curl", "-f", "-k", "https://localhost"]
+      test: ["CMD", "curl", "-m", "1", "-f", "-k", "https://localhost"]
       interval: 1s
       timeout: 3s
-      retries: 60
+      retries: 10


### PR DESCRIPTION
the PR updates the integration tests to exercise `PersistentProxyHandler` and `RendezvousHash`