### PR TITLE
zk exhibitor integration

### DIFF
--- a/exhibitor-test-app/build.gradle
+++ b/exhibitor-test-app/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'java'
+  id 'application'
+}
+
+mainClassName = 'com.xjeffrose.xio.exhibitor.Main'
+
+dependencies {
+  implementation project(':xio')
+  implementation(group: 'org.apache.curator', name: 'curator-recipes', version: curator_version) {
+    exclude(module: 'zookeeper')
+  }
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: logback_version
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: logback_version
+  implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: groovy_version
+}

--- a/exhibitor-test-app/src/main/java/com/xjeffrose/xio/exhibitor/Main.java
+++ b/exhibitor-test-app/src/main/java/com/xjeffrose/xio/exhibitor/Main.java
@@ -1,0 +1,22 @@
+package com.xjeffrose.xio.exhibitor;
+
+import com.xjeffrose.xio.application.Application;
+import com.xjeffrose.xio.bootstrap.ApplicationBootstrap;
+import com.xjeffrose.xio.pipeline.SmartHttpPipeline;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Main {
+  public static void main(String args[]) throws Exception {
+    Application application = new ApplicationBootstrap("exhibitor-test")
+	.addServer("main", bs -> bs.addToPipeline(new SmartHttpPipeline()))
+        .build();
+
+    application.getState()
+      .getZkClient()
+      .getClient()
+      .create()
+      .creatingParentsIfNeeded()
+      .forPath("/test/key", "value".getBytes());
+  }
+}

--- a/exhibitor-test-app/src/main/resources/application.conf
+++ b/exhibitor-test-app/src/main/resources/application.conf
@@ -1,0 +1,11 @@
+exhibitor-test = ${xio.applicationTemplate} {
+  name = "test application"
+  servers {
+    main = ${xio.serverTemplate} {
+      name = "test server"
+      settings {
+        bindPort = 0
+      }
+    }
+  }
+}

--- a/exhibitor-test-app/src/main/resources/logback.groovy
+++ b/exhibitor-test-app/src/main/resources/logback.groovy
@@ -1,0 +1,24 @@
+import ch.qos.logback.classic.filter.ThresholdFilter
+import ch.qos.logback.classic.PatternLayout
+
+// make changes for dev appender here
+appender("DEV-CONSOLE", ConsoleAppender) {
+  withJansi = true
+
+  filter(ThresholdFilter) {
+    level = DEBUG
+  }
+  encoder(PatternLayoutEncoder) {
+    pattern = "%-4relative [%thread] %-5level %logger{30} - %msg%n"
+    outputPatternAsHeader = false
+  }
+}
+
+logger("com.xjeffrose.xio.config.ConfigReloader", OFF)
+logger("com.xjeffrose.xio.SSL.XioTrustManagerFactory", OFF)
+logger("com.xjeffrose.xio.core.NullZkClient", OFF)
+logger("io.netty.channel.DefaultChannelPipeline", DEBUG)
+logger("io.netty.util.internal.NativeLibraryLoader", ERROR)
+logger("io.netty.handler.ssl.CipherSuiteConverter", OFF)
+
+root(ALL, ["DEV-CONSOLE"])

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ include ':xio'
 include ':xio-test'
 include ':configuration-server'
 include 'chicago-example'
+include 'exhibitor-test-app'
 include 'int-test-backend-server'
 include 'int-test-proxy-server'
 

--- a/xio-core/build.gradle
+++ b/xio-core/build.gradle
@@ -9,6 +9,8 @@ plugins {
 
 googleJavaFormat {
   exclude "out/**/*"
+  exclude "target/generated-sources/**/*.java"
+  exclude "target/generated-test-sources/**/*.java"
 }
 
 jacocoTestReport {

--- a/xio-core/src/test/java/com/xjeffrose/xio/core/ZkClientFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/core/ZkClientFunctionalTest.java
@@ -1,7 +1,7 @@
 package com.xjeffrose.xio.core;
 
-import java.util.List;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.mockwebserver.MockResponse;

--- a/xio-core/src/test/java/com/xjeffrose/xio/core/ZkClientFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/core/ZkClientFunctionalTest.java
@@ -1,8 +1,11 @@
 package com.xjeffrose.xio.core;
 
 import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -14,6 +17,23 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ZkClientFunctionalTest extends Assert {
+
+  @Test
+  public void testFromExhibitor() throws Exception {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "count=5&server0=10.10.1.1&server1=10.10.1.2&server2=10.10.1.3&server3=10.10.1.4&server4=10.10.1.5&port=2181")
+            .setHeader("Content-Type", "application/x-www-form-urlencoded"));
+    server.start();
+    ZkClient client = ZkClient.fromExhibitor(Arrays.asList("127.0.0.1"), server.getPort());
+
+    assertEquals(
+        "10.10.1.1:2181,10.10.1.2:2181,10.10.1.3:2181,10.10.1.4:2181,10.10.1.5:2181",
+        client.getConnectionString());
+    server.shutdown();
+  }
 
   @Test
   public void testUpdaterBeforeStart() throws Exception {


### PR DESCRIPTION
This PR sets up the `Application` class's `ZkClient` to be used with an exhibitor ensemble.

  * If `settings.zookeeper.cluster` starts with "ensemble" the string will be parsed with this assumed format: "ensemble:<port>:<server1>,<server2>,<serverN>"
  * A simple app is included to test with a proper exhibitor ensemble
  * A flaky test was also fixed
  * verifyGoogleJavaFormat now ignores more generate sources