### PR TITLE
dc/TACO-424 updated the socket address helper to append the port to t…

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/core/SocketAddressHelper.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/core/SocketAddressHelper.java
@@ -10,24 +10,24 @@ import lombok.val;
 public class SocketAddressHelper {
 
   @Nullable
-  public String extractRemoteAddress(Channel channel) {
+  public String extractRemoteAddressAndPort(Channel channel) {
     if (channel instanceof ServerSocketChannel) {
       val inetSocketAddress = ((ServerSocketChannel) channel).remoteAddress();
-      return computeAddress(inetSocketAddress);
+      return computeAddressAndPort(inetSocketAddress);
     } else if (channel instanceof SocketChannel) {
       val inetSocketAddress = ((SocketChannel) channel).remoteAddress();
-      return computeAddress(inetSocketAddress);
+      return computeAddressAndPort(inetSocketAddress);
     } else {
       return null;
     }
   }
 
   @Nullable
-  private String computeAddress(InetSocketAddress inetSocketAddress) {
+  private String computeAddressAndPort(InetSocketAddress inetSocketAddress) {
     if (inetSocketAddress != null) {
       val inetAddress = inetSocketAddress.getAddress();
       if (inetAddress != null) {
-        return inetAddress.getHostAddress();
+        return inetAddress.getHostAddress() + ":" + String.valueOf(inetSocketAddress.getPort());
       }
     }
     return null;

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/PersistentProxyHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/PersistentProxyHandler.java
@@ -39,10 +39,11 @@ public class PersistentProxyHandler extends ProxyHandler {
 
   @Override
   public Optional<ClientConfig> getClientConfig(ChannelHandlerContext ctx, Request request) {
-    String originatingAddress = getOriginatingAddress(ctx, request);
+    String originatingAddressAndPort = getOriginatingAddressAndPort(ctx, request);
     if (clientConfigMap.size() > 0) {
       val hasherPoolId =
-          persistentProxyHasher.getOne(originatingAddress.getBytes(Constants.DEFAULT_CHARSET));
+          persistentProxyHasher.getOne(
+              originatingAddressAndPort.getBytes(Constants.DEFAULT_CHARSET));
       return Optional.of(clientConfigMap.get(hasherPoolId));
     }
     return Optional.empty();

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyHandler.java
@@ -95,10 +95,10 @@ public class ProxyHandler implements PipelineRequestHandler {
     return result;
   }
 
-  protected String getOriginatingAddress(ChannelHandlerContext ctx, Request request) {
+  protected String getOriginatingAddressAndPort(ChannelHandlerContext ctx, Request request) {
     val rawXFF = request.headers().get(X_FORWARDED_FOR);
     if (rawXFF == null || rawXFF.toString().trim().isEmpty()) {
-      return addressHelper.extractRemoteAddress(ctx.channel());
+      return addressHelper.extractRemoteAddressAndPort(ctx.channel());
     } else {
       String stringXFF = rawXFF.toString();
       if (stringXFF.contains(",")) {
@@ -112,13 +112,13 @@ public class ProxyHandler implements PipelineRequestHandler {
   }
 
   private void appendXForwardedFor(ChannelHandlerContext ctx, Request request) {
-    val remoteAddress = addressHelper.extractRemoteAddress(ctx.channel());
-    if (remoteAddress != null) {
+    val remoteAddressAndPort = addressHelper.extractRemoteAddressAndPort(ctx.channel());
+    if (remoteAddressAndPort != null) {
       val rawXFF = request.headers().get(X_FORWARDED_FOR);
       if (rawXFF == null || rawXFF.toString().trim().isEmpty()) {
-        request.headers().set(X_FORWARDED_FOR, remoteAddress);
+        request.headers().set(X_FORWARDED_FOR, remoteAddressAndPort);
       } else {
-        val newXFF = rawXFF.toString().trim() + ", " + remoteAddress;
+        val newXFF = rawXFF.toString().trim() + ", " + remoteAddressAndPort;
         request.headers().set(X_FORWARDED_FOR, newXFF);
       }
     }

--- a/xio-core/src/test/java/com/xjeffrose/xio/core/SocketAddressHelperTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/core/SocketAddressHelperTest.java
@@ -27,7 +27,7 @@ public class SocketAddressHelperTest extends Assert {
 
   @Test
   public void testNonSocketOrSocketServerChannel() throws Exception {
-    val result = subject.extractRemoteAddress(channel);
+    val result = subject.extractRemoteAddressAndPort(channel);
     assertTrue(result == null);
   }
 
@@ -35,7 +35,7 @@ public class SocketAddressHelperTest extends Assert {
   public void testWithoutInetSocketAddressSocketServerChannel() throws Exception {
     when(serverSocketChannel.remoteAddress()).thenReturn(null);
 
-    val result = subject.extractRemoteAddress(serverSocketChannel);
+    val result = subject.extractRemoteAddressAndPort(serverSocketChannel);
     assertTrue(result == null);
   }
 
@@ -43,26 +43,30 @@ public class SocketAddressHelperTest extends Assert {
   public void testInetSocketAddressSocketChannel() throws Exception {
     when(socketChannel.remoteAddress()).thenReturn(null);
 
-    val result = subject.extractRemoteAddress(socketChannel);
+    val result = subject.extractRemoteAddressAndPort(socketChannel);
     assertTrue(result == null);
   }
 
   @Test
   public void testValidAddressSocketServerChannel() throws Exception {
+    val testPort = 123;
     val testAddress = "192.168.0.1";
-    val inetSocketAddress = new InetSocketAddress(testAddress, 123);
+    val inetSocketAddress = new InetSocketAddress(testAddress, testPort);
+    val expectedResult = testAddress + ":" + String.valueOf(testPort);
     when(serverSocketChannel.remoteAddress()).thenReturn(inetSocketAddress);
 
-    val result = subject.extractRemoteAddress(serverSocketChannel);
-    assertTrue(result.equals(testAddress));
+    val result = subject.extractRemoteAddressAndPort(serverSocketChannel);
+    assertTrue(result.equals(expectedResult));
   }
 
   @Test
   public void testValidAddressSocketChannel() throws Exception {
+    val testPort = 2;
     val testAddress = "192.168.0.1";
-    val inetSocketAddress = new InetSocketAddress(testAddress, 2);
+    val inetSocketAddress = new InetSocketAddress(testAddress, testPort);
+    val expectedResult = testAddress + ":" + String.valueOf(testPort);
     when(socketChannel.remoteAddress()).thenReturn(inetSocketAddress);
-    val result = subject.extractRemoteAddress(socketChannel);
-    assertTrue(result.equals(testAddress));
+    val result = subject.extractRemoteAddressAndPort(socketChannel);
+    assertTrue(result.equals(expectedResult));
   }
 }

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/ClientConnectionManagerIntegrationTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/ClientConnectionManagerIntegrationTest.java
@@ -94,7 +94,7 @@ public class ClientConnectionManagerIntegrationTest extends Assert {
     Future<Void> connectionResult = subject.connect();
     assertEquals(ClientConnectionState.CONNECTING, subject.connectionState());
     try {
-      connectionResult.get(5, TimeUnit.SECONDS);
+      connectionResult.get(30, TimeUnit.SECONDS);
     } catch (Exception e) {
 
     } finally {


### PR DESCRIPTION
 updated the socket address helper to append the port to the address string, I did not want to do a string split on inetsocketaddress so I am composing it using inetaddress.getHostAddress and inetsocketaddress.getPort, this will let us test the load balancing without spinning up 10,000 hosts