### PR TITLE
Dc/taco 597 added sweet copy constructors and factory method on route states

### DIFF
--- a/int-test-proxy-server/src/main/java/com/xjeffrose/xio/proxy/RouteStates.java
+++ b/int-test-proxy-server/src/main/java/com/xjeffrose/xio/proxy/RouteStates.java
@@ -21,7 +21,7 @@ public class RouteStates {
         Stream.of(proxyRouteConfig)
             .map(
                 (ProxyRouteConfig config) ->
-                    new ProxyRouteState(
+                    ProxyRouteState.create(
                         applicationState,
                         config,
                         new PersistentProxyHandler(

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyRouteState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyRouteState.java
@@ -16,9 +16,33 @@ public class ProxyRouteState extends RouteState {
     return Route.build(config.path() + ":*path");
   }
 
+  public static ProxyRouteState create(
+      ApplicationState state, ProxyRouteConfig config, ProxyHandler handler) {
+    List<ClientConfig> configs = config.clientConfigs();
+    List<ClientState> clientStates =
+        configs
+            .stream()
+            .map(clientConfig -> new ClientState(clientConfig, state.workerGroup()))
+            .collect(Collectors.toList());
+    return new ProxyRouteState(config, handler, clientStates);
+  }
+
+  // copy constructor with new clientstates
+  public ProxyRouteState(ProxyRouteState routeState, List<ClientState> clientStates) {
+    super(routeState);
+    this.clientStates = clientStates;
+  }
+
+  public ProxyRouteState(
+      ProxyRouteConfig config, ProxyHandler handler, List<ClientState> clientStates) {
+    super(ProxyRouteState::buildRoute, config, handler);
+    this.clientStates = clientStates;
+  }
+
   // TODO(CK): This constructor is goofy and should be replaced with a factory method
   // the new constructor should be ProxyRouteState(ProxyRouteConfig, ProxyHandler,
   // List<ClientStates>)
+  /*
   public ProxyRouteState(ApplicationState state, ProxyRouteConfig config, ProxyHandler handler) {
     super(ProxyRouteState::buildRoute, config, handler);
     List<ClientConfig> configs = config.clientConfigs();
@@ -28,6 +52,7 @@ public class ProxyRouteState extends RouteState {
             .map(clientConfig -> new ClientState(clientConfig, state.workerGroup()))
             .collect(Collectors.toList());
   }
+  */
 
   @Override
   public ProxyHandler handler() {

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyRouteState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/ProxyRouteState.java
@@ -39,21 +39,6 @@ public class ProxyRouteState extends RouteState {
     this.clientStates = clientStates;
   }
 
-  // TODO(CK): This constructor is goofy and should be replaced with a factory method
-  // the new constructor should be ProxyRouteState(ProxyRouteConfig, ProxyHandler,
-  // List<ClientStates>)
-  /*
-  public ProxyRouteState(ApplicationState state, ProxyRouteConfig config, ProxyHandler handler) {
-    super(ProxyRouteState::buildRoute, config, handler);
-    List<ClientConfig> configs = config.clientConfigs();
-    clientStates =
-        configs
-            .stream()
-            .map(clientConfig -> new ClientState(clientConfig, state.workerGroup()))
-            .collect(Collectors.toList());
-  }
-  */
-
   @Override
   public ProxyHandler handler() {
     return (ProxyHandler) super.handler();

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/RouteState.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/RouteState.java
@@ -16,6 +16,13 @@ public class RouteState {
     return Route.build(config.path());
   }
 
+  // copy constructor
+  public RouteState(RouteState routeState) {
+    this.config = routeState.config;
+    this.route = routeState.route;
+    this.handler = routeState.handler;
+  }
+
   public RouteState(
       Function<RouteConfig, Route> factory, RouteConfig config, PipelineRequestHandler handler) {
     this.config = config;

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/EdgeProxyFunctionalTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/EdgeProxyFunctionalTest.java
@@ -133,7 +133,7 @@ public class EdgeProxyFunctionalTest extends Assert {
                       // for each ProxyRouteConfig create a ProxyRouteState
                       .map(
                           (ProxyRouteConfig prConfig) ->
-                              new ProxyRouteState(
+                              ProxyRouteState.create(
                                   this,
                                   prConfig,
                                   new ProxyHandler(

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcProxyTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcProxyTest.java
@@ -139,7 +139,7 @@ public class GrpcProxyTest extends Assert {
                     return new PipelineRouter(
                         ImmutableMap.of(
                             "*",
-                            new ProxyRouteState(
+                            ProxyRouteState.create(
                                 appState,
                                 proxyConfig,
                                 new ProxyHandler(


### PR DESCRIPTION
In order to facilite creating new routeState objects based on a filtered clientStates I am adding copy constructors to RouteState/ProxyRouteState