### PR TITLE
TACO-590 replace * with none keyword to represent none

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/grpc/GrpcRouteStateBuilder.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/grpc/GrpcRouteStateBuilder.java
@@ -22,7 +22,7 @@ public class GrpcRouteStateBuilder {
 
         List<HttpMethod> methods = Collections.singletonList(HttpMethod.POST);
         String host = "";
-        String permissionNeeded = "*";
+        String permissionNeeded = "none";
 
         RouteConfig config = new RouteConfig(methods, host, route.buildPath(), permissionNeeded);
         routeStates.add(new RouteState(config, route.handler));

--- a/xio-core/src/main/java/com/xjeffrose/xio/http/PathToRequestHandler.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/PathToRequestHandler.java
@@ -16,7 +16,7 @@ public class PathToRequestHandler {
       ImmutableMap<String, RouteState> routes, PipelineRequestHandler defaultHandler) {
     this.routes = routes;
     RouteState defaultRoute = RouteState.defaultRoute(defaultHandler);
-    defaultEntry = new AbstractMap.SimpleEntry("*", defaultRoute);
+    defaultEntry = new AbstractMap.SimpleEntry("none", defaultRoute);
   }
 
   public PathToRequestHandler(PipelineRequestHandler handler) {

--- a/xio-core/src/main/resources/reference.conf
+++ b/xio-core/src/main/resources/reference.conf
@@ -207,7 +207,7 @@ xio {
     methods = []
     host = ""
     path = "/"
-    permissionNeeded = "*"
+    permissionNeeded = "none"
   }
 
   proxyRouteTemplate = ${xio.routeTemplate} {

--- a/xio-core/src/test/java/com/xjeffrose/xio/grpc/GrpcRouteStateBuilderTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/grpc/GrpcRouteStateBuilderTest.java
@@ -33,7 +33,7 @@ public class GrpcRouteStateBuilderTest extends Assert {
         Collections.singletonList(HttpMethod.POST), registerServiceRouteState.config().methods());
     assertEquals("", registerServiceRouteState.config().host());
     assertEquals(grpcRoute.buildPath(), registerServiceRouteState.path());
-    assertEquals("*", registerServiceRouteState.config().permissionNeeded());
+    assertEquals("none", registerServiceRouteState.config().permissionNeeded());
     assertEquals(grpcRoute.handler, registerServiceRouteState.handler());
   }
 

--- a/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcProxyTest.java
+++ b/xio-core/src/test/java/com/xjeffrose/xio/http/GrpcProxyTest.java
@@ -138,7 +138,7 @@ public class GrpcProxyTest extends Assert {
                   public ChannelHandler getApplicationRouter() {
                     return new PipelineRouter(
                         ImmutableMap.of(
-                            "*",
+                            "none",
                             ProxyRouteState.create(
                                 appState,
                                 proxyConfig,


### PR DESCRIPTION
Replace the permissionNeeded property value of `*` with the keyword `none` to represent "no permission needed to proxy route" * was misleading in this use case as it typically represents everything rather than nothing.

Note: * causes authZ to deny the request with a 401 rather than a 404 when an unknown route is encountered.