### PR TITLE
add client auth option to ssl context builder

### DIFF
--- a/xio-tls/src/main/java/com/xjeffrose/xio/tls/SslContextFactory.java
+++ b/xio-tls/src/main/java/com/xjeffrose/xio/tls/SslContextFactory.java
@@ -1,5 +1,6 @@
 package com.xjeffrose.xio.tls;
 
+import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -9,6 +10,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 
@@ -31,10 +33,19 @@ public class SslContextFactory {
   }
 
   public static SslContext buildServerContext(TlsConfig config, TrustManagerFactory trustManager) {
+    return buildServerContext(config, trustManager, null);
+  }
+
+  public static SslContext buildServerContext(TlsConfig config, TrustManagerFactory trustManager, @Nullable ClientAuth clientAuth) {
     try {
-      return configure(config, newServerBuilder(config))
-          .trustManager(new XioTrustManagerFactory(trustManager))
-          .build();
+      SslContextBuilder builder = configure(config, newServerBuilder(config))
+        .trustManager(new XioTrustManagerFactory(trustManager));
+
+      if (clientAuth != null) {
+        builder.clientAuth(clientAuth);
+      }
+
+      return builder.build();
     } catch (SSLException e) {
       return null;
     }
@@ -42,6 +53,10 @@ public class SslContextFactory {
 
   public static SslContext buildServerContext(TlsConfig config) {
     return buildServerContext(config, buildTrustManagerFactory(config.getTrustedCerts()));
+  }
+
+  public static SslContext buildServerContext(TlsConfig config, ClientAuth clientAuth) {
+    return buildServerContext(config, buildTrustManagerFactory(config.getTrustedCerts()), clientAuth);
   }
 
   public static SslContext buildClientContext(TlsConfig config, TrustManagerFactory trustManager) {

--- a/xio-tls/src/main/java/com/xjeffrose/xio/tls/SslContextFactory.java
+++ b/xio-tls/src/main/java/com/xjeffrose/xio/tls/SslContextFactory.java
@@ -36,10 +36,12 @@ public class SslContextFactory {
     return buildServerContext(config, trustManager, null);
   }
 
-  public static SslContext buildServerContext(TlsConfig config, TrustManagerFactory trustManager, @Nullable ClientAuth clientAuth) {
+  public static SslContext buildServerContext(
+      TlsConfig config, TrustManagerFactory trustManager, @Nullable ClientAuth clientAuth) {
     try {
-      SslContextBuilder builder = configure(config, newServerBuilder(config))
-        .trustManager(new XioTrustManagerFactory(trustManager));
+      SslContextBuilder builder =
+          configure(config, newServerBuilder(config))
+              .trustManager(new XioTrustManagerFactory(trustManager));
 
       if (clientAuth != null) {
         builder.clientAuth(clientAuth);
@@ -56,7 +58,8 @@ public class SslContextFactory {
   }
 
   public static SslContext buildServerContext(TlsConfig config, ClientAuth clientAuth) {
-    return buildServerContext(config, buildTrustManagerFactory(config.getTrustedCerts()), clientAuth);
+    return buildServerContext(
+        config, buildTrustManagerFactory(config.getTrustedCerts()), clientAuth);
   }
 
   public static SslContext buildClientContext(TlsConfig config, TrustManagerFactory trustManager) {


### PR DESCRIPTION
Adding overload method to SslContextFactory so that you can optionally specify https://netty.io/4.1/api/index.html?io/netty/handler/ssl/ClientAuth.html options for server ssl context.