### PR TITLE
TACO-687 - return the wrapped request's host when the request is a Se…

### DIFF
--- a/xio-core/src/main/java/com/xjeffrose/xio/http/SegmentedRequestData.java
+++ b/xio-core/src/main/java/com/xjeffrose/xio/http/SegmentedRequestData.java
@@ -27,6 +27,11 @@ public class SegmentedRequestData implements Request, SegmentedData {
   // region Request
 
   @Override
+  public String host() {
+    return request.host();
+  }
+
+  @Override
   public boolean startOfMessage() {
     return false;
   }


### PR DESCRIPTION
…gmentedRequestData

Previously, if the contained request was an H2 request, this implementation was returning the default Request implementation which assumes a host header (H1 requirement).