### PR TITLE
Added sources and javadoc to each artifact

### DIFF
--- a/xio-core/build.gradle
+++ b/xio-core/build.gradle
@@ -94,6 +94,16 @@ sourceSets {
   }
 }
 
+// Used below to add javadoc + sources jars to the published artifacts list.
+task javadocJar(type: Jar) {
+  classifier = 'javadoc'
+  from javadoc
+}
+task sourcesJar(type: Jar) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
 bintray_package = 'xio'
 publishing {
   publications {
@@ -102,6 +112,8 @@ publishing {
       artifactId bintray_package
       version version
       from components.java
+      artifact sourcesJar
+      artifact javadocJar
     }
   }
 }

--- a/xio-test/build.gradle
+++ b/xio-test/build.gradle
@@ -15,6 +15,16 @@ dependencies {
   api group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4j_version
 }
 
+// Used below to add javadoc + sources jars to the published artifacts list.
+task javadocJar(type: Jar) {
+  classifier = 'javadoc'
+  from javadoc
+}
+task sourcesJar(type: Jar) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
 bintray_package = 'xio-test'
 publishing {
   publications {
@@ -23,6 +33,8 @@ publishing {
       artifactId bintray_package
       version version
       from components.java
+      artifact sourcesJar
+      artifact javadocJar
     }
   }
 }

--- a/xio-tls/build.gradle
+++ b/xio-tls/build.gradle
@@ -9,6 +9,16 @@ plugins {
 description = 'xio-tls'
 group = project_group
 
+// Used below to add javadoc + sources jars to the published artifacts list.
+task javadocJar(type: Jar) {
+  classifier = 'javadoc'
+  from javadoc
+}
+task sourcesJar(type: Jar) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
 bintray_package = 'xio-tls'
 publishing {
   publications {
@@ -17,6 +27,8 @@ publishing {
       artifactId bintray_package
       version version
       from components.java
+      artifact sourcesJar
+      artifact javadocJar
     }
   }
 }

--- a/xio-zookeeper/build.gradle
+++ b/xio-zookeeper/build.gradle
@@ -48,6 +48,16 @@ dependencies {
   }
 }
 
+// Used below to add javadoc + sources jars to the published artifacts list.
+task javadocJar(type: Jar) {
+  classifier = 'javadoc'
+  from javadoc
+}
+task sourcesJar(type: Jar) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
 bintray_package = 'xio-zookeeper'
 publishing {
   publications {
@@ -56,6 +66,8 @@ publishing {
       artifactId bintray_package
       version version
       from components.java
+      artifact sourcesJar
+      artifact javadocJar
     }
   }
 }


### PR DESCRIPTION
bintray jcenter has changed their policies for packages, we now need to include sources. This PR includes sources and javadoc which brings it in line with xrpc.